### PR TITLE
Multithreaded render script

### DIFF
--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -40,7 +40,7 @@ class Media:
             self.proxy_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            universal_newlines=True, )
+            universal_newlines=True)
         process.wait()
         print("progress: 100%")
         print("Done!", "\n")
@@ -123,7 +123,7 @@ class Video(Media):
             self.proxy_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            universal_newlines=True, )
+            universal_newlines=True)
 
         for line in process.stdout:
             progress = int(line[line.index("=") + 2:line.index(" f")].strip())

--- a/scripts/render_video_multithreaded.py
+++ b/scripts/render_video_multithreaded.py
@@ -21,8 +21,7 @@ import sys
 # with that being our default, this constant makes sense
 CPUS_COUNT = min(int(multiprocessing.cpu_count() / 2), 6)
 
-FRAME_RANGE_SCRIPT = \
-"""\
+FRAME_RANGE_SCRIPT = """\
 import bpy
 
 scene = bpy.context.scene
@@ -30,8 +29,7 @@ print("START %d" % (scene.frame_start))
 print("END %d" % (scene.frame_end))
 """
 
-MIXDOWN_SCRIPT = \
-"""\
+MIXDOWN_SCRIPT = """\
 import bpy
 scene = bpy.context.scene
 sed = scene.sequence_editor
@@ -42,72 +40,67 @@ for strip in sequences:
 bpy.ops.sound.mixdown(filepath="%s", check_existing=False, relative_path=False, container="FLAC", codec="FLAC")
 """
 
-BLENDER_CMD_TEMPLATE = [
-    'blender',
-    '-b',
-    '',
-    '-P',
-    ''
-]
+BLENDER_CMD_TEMPLATE = ["blender", "-b", "", "-P", ""]
 
 BLENDER_CHUNK_RENDER_CMD_TEMPLATE = [
-    'blender',
-    '-b',
-    '',
-    '-s',
-    '',
-    '-e',
-    '',
-    '-o',
-    '',
-    '-a'
+    "blender",
+    "-b",
+    "",
+    "-s",
+    "",
+    "-e",
+    "",
+    "-o",
+    "",
+    "-a",
 ]
 
 BLENDER_AUDIO_MIXDOWN_CMD_TEMPLATE = [
-    'blender',
-    '-b',
-    '',
-    '-s',
-    '',
-    '-e',
-    '',
-    '-o',
-    '',
-    '-P',
-    ''
+    "blender",
+    "-b",
+    "",
+    "-s",
+    "",
+    "-e",
+    "",
+    "-o",
+    "",
+    "-P",
+    "",
 ]
 
 FFMPEG_CONCAT_VIDEO_CMD_TEMPLATE = [
-    'ffmpeg',
-    '-stats',
-    '-f',
-    'concat',
-    '-safe',
-    '-0',
-    '-i',
-    '',
-    '-c',
-    'copy',
-    '-y',
-    ''
+    "ffmpeg",
+    "-stats",
+    "-f",
+    "concat",
+    "-safe",
+    "-0",
+    "-i",
+    "",
+    "-c",
+    "copy",
+    "-y",
+    "",
 ]
 
 FFMPEG_JOIN_AUDIO_CMD_TEMPLATE = [
-    'ffmpeg',
-    '-stats',
-    '-i',
-    '',
-    '-i',
-    '',
-    '-c:v',
-    'copy',
-    '-map',
-    '0:v:0',
-    '-map', 
-    '1:a:0',
-    '-y',
-    ''
+    "ffmpeg",
+    "-stats",
+    "-i",
+    "",
+    "-i",
+    "",
+    "-c:v",
+    "copy",
+    "-map",
+    "0:v:0",
+    "-map",
+    "1:a:0",
+    "-y",
+    "",
 ]
+
 
 def get_project_info(blendfile):
     """
@@ -115,13 +108,13 @@ def get_project_info(blendfile):
     generates the render path, and returns the trio as a tuple
     """
 
-    print('~~ probing blendfile for project info... ', end='')
+    print("~~ probing blendfile for project info... ", end="")
     script_path = os.path.dirname(os.path.abspath(__file__))
-    frame_range_script_path = os.path.join(script_path, 'temp_frame_range_script.py')
+    frame_range_script_path = os.path.join(script_path, "temp_frame_range_script.py")
 
-    with open(frame_range_script_path, 'w+') as script:
+    with open(frame_range_script_path, "w+") as script:
         script.write(FRAME_RANGE_SCRIPT)
-    
+
     info_cmd = [arg for arg in BLENDER_CMD_TEMPLATE]
     info_cmd[2] = blendfile
     info_cmd[-1] = frame_range_script_path
@@ -130,22 +123,24 @@ def get_project_info(blendfile):
         info_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True)
+        universal_newlines=True,
+    )
 
     frame_start = 0
     frame_end = 0
     render_path = os.path.join(os.path.split(blendfile)[0], "render")
-    
+
     for line in process.stdout:
         if line.startswith("START"):
             frame_start = int(line.split()[1])
         elif line.startswith("END"):
             frame_end = int(line.split()[1])
-                
+
     os.remove(frame_range_script_path)
 
-    print('Done!\n')
+    print("Done!\n")
     return (frame_start, frame_end, render_path)
+
 
 def gen_render_process_args(render_setting, start_frame, end_frame, render_path):
     """
@@ -153,15 +148,15 @@ def gen_render_process_args(render_setting, start_frame, end_frame, render_path)
     """
     blendfile, workers = render_setting
 
-    chunk_path = os.path.join(render_path, 'render_parts', "render_chunk_")
+    chunk_path = os.path.join(render_path, "render_parts", "render_chunk_")
 
     render_cmd = [arg for arg in BLENDER_CHUNK_RENDER_CMD_TEMPLATE]
 
     render_cmd[2] = blendfile
-    render_cmd[4]= '%s' % start_frame
-    render_cmd[6]= '%s' % end_frame
+    render_cmd[4] = "%s" % start_frame
+    render_cmd[6] = "%s" % end_frame
     render_cmd[8] = chunk_path
-    
+
     return render_cmd
 
 
@@ -170,7 +165,7 @@ def gen_render_chunk_cmds(render_setting, frame_start, frame_end, render_path):
     Returns a list of cmds to run in order to generate chunks
     """
     total_frames = frame_end - frame_start
-    blendfile, workers =  render_setting
+    blendfile, workers = render_setting
     chunk_frames = int(math.floor(total_frames / workers))
 
     render_chunk_cmds = []
@@ -182,9 +177,14 @@ def gen_render_chunk_cmds(render_setting, frame_start, frame_end, render_path):
         else:
             w_end_frame = w_start_frame + chunk_frames - 1
 
-        render_chunk_cmds.append(gen_render_process_args(render_setting, w_start_frame, w_end_frame, render_path))
+        render_chunk_cmds.append(
+            gen_render_process_args(
+                render_setting, w_start_frame, w_end_frame, render_path
+            )
+        )
 
     return render_chunk_cmds
+
 
 def render_chunk(chunk_cmd):
     """
@@ -196,7 +196,7 @@ def render_chunk(chunk_cmd):
     subprocess.check_output(chunk_cmd, stderr=subprocess.STDOUT)
 
 
-# many thanks to this blog post: 
+# many thanks to this blog post:
 # https://rsmith.home.xs4all.nl/programming/parallel-execution-with-python.html
 
 
@@ -204,12 +204,15 @@ def render_video_multiprocess(render_setting, frame_start, frame_end, render_pat
     """
     manages the chunk rendering processes via a pool
     """
-    chunk_cmds = gen_render_chunk_cmds(render_setting, frame_start, frame_end, render_path)
+    chunk_cmds = gen_render_chunk_cmds(
+        render_setting, frame_start, frame_end, render_path
+    )
 
     pool = multiprocessing.Pool(processes=(len(chunk_cmds)))
     pool.map(render_chunk, chunk_cmds)
     pool.close()
     pool.join()
+
 
 def render_audio(render_setting, frame_start, frame_end, render_path):
     """
@@ -218,32 +221,35 @@ def render_audio(render_setting, frame_start, frame_end, render_path):
     blendfile, workers = render_setting
 
     script_path = os.path.dirname(os.path.abspath(__file__))
-    mixdown_script_path = os.path.join(script_path, 'mixdown_script.py')
+    mixdown_script_path = os.path.join(script_path, "mixdown_script.py")
 
-    mixdown_path = os.path.join(render_path, 'render_parts', "mixdown.flac")
+    mixdown_path = os.path.join(render_path, "render_parts", "mixdown.flac")
 
-    with open(mixdown_script_path, 'w+') as script:
+    with open(mixdown_script_path, "w+") as script:
         script.write(MIXDOWN_SCRIPT % mixdown_path)
 
     mixdown_cmd = [arg for arg in BLENDER_AUDIO_MIXDOWN_CMD_TEMPLATE]
     mixdown_cmd[2] = blendfile
-    mixdown_cmd[4] = '%s' % frame_start
-    mixdown_cmd[6] = '%s' % frame_end
+    mixdown_cmd[4] = "%s" % frame_start
+    mixdown_cmd[6] = "%s" % frame_end
     mixdown_cmd[8] = mixdown_path
     mixdown_cmd[10] = mixdown_script_path
 
-    subprocess.Popen(mixdown_cmd,
+    subprocess.Popen(
+        mixdown_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True).wait()
+        universal_newlines=True,
+    ).wait()
 
     os.remove(mixdown_script_path)
+
 
 def render_multiprocess(render_setting, frame_start, frame_end, render_path):
     """
     Renders the video and the audio from ffmpeg
     """
-    print('~~ rendering video / audio parts... ', end='')
+    print("~~ rendering video / audio parts... ", end="")
     render_video_multiprocess(render_setting, frame_start, frame_end, render_path)
     render_audio(render_setting, frame_start, frame_end, render_path)
     print("Done!\n")
@@ -254,19 +260,18 @@ def concat_chunks(render_path):
     Calls in ffmpeg to concat the chunks. also returns the path to the newly 
     created file
     """
-    parts_dir = os.path.join(render_path, 'render_parts')
+    parts_dir = os.path.join(render_path, "render_parts")
     chunk_list_path = os.path.join(parts_dir, "chunk_list.txt")
-    
 
     chunk_list = []
-    with open(chunk_list_path, 'w+') as chunk_list_file:
+    with open(chunk_list_path, "w+") as chunk_list_file:
         for file in os.listdir(parts_dir):
-            if file.startswith('render_chunk_'):
+            if file.startswith("render_chunk_"):
                 chunk_list.append(file)
-        chunk_list = (sorted(chunk_list))
+        chunk_list = sorted(chunk_list)
         for chunk in chunk_list:
-            chunk_list_file.write('file ' + chunk + '\n')
-    
+            chunk_list_file.write("file " + chunk + "\n")
+
     ext = os.path.splitext(chunk_list[0])[1]
     concat_path = os.path.join(parts_dir, "video_concat%s" % ext)
 
@@ -274,14 +279,17 @@ def concat_chunks(render_path):
     concat_cmd[7] = chunk_list_path
     concat_cmd[11] = concat_path
 
-    subprocess.Popen(concat_cmd,
+    subprocess.Popen(
+        concat_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True).wait()
+        universal_newlines=True,
+    ).wait()
 
     os.remove(chunk_list_path)
 
     return (concat_path, ext)
+
 
 def join_parts(render_path):
     """
@@ -289,53 +297,57 @@ def join_parts(render_path):
     render
     """
 
-    print('~~ now joining parts to make final render... ', end='')
+    print("~~ now joining parts to make final render... ", end="")
     video_concat_path, ext = concat_chunks(render_path)
-    mixdown_path = os.path.join(render_path, 'render_parts', "mixdown.flac")
+    mixdown_path = os.path.join(render_path, "render_parts", "mixdown.flac")
 
     join_cmd = [arg for arg in FFMPEG_JOIN_AUDIO_CMD_TEMPLATE]
     join_cmd[3] = video_concat_path
     join_cmd[5] = mixdown_path
-    join_cmd[13] = os.path.join(render_path, 'render%s' % ext)
+    join_cmd[13] = os.path.join(render_path, "render%s" % ext)
 
-    subprocess.Popen(join_cmd,
+    subprocess.Popen(
+        join_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        universal_newlines=True).wait()
+        universal_newlines=True,
+    ).wait()
 
-    print('Done!\n')
+    print("Done!\n")
 
 
 def parse_arguments():
     ap = argparse.ArgumentParser(
         description="Multi-process Blender VSE rendering",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     ap.add_argument(
-        '-w',
-        '--workers',
+        "-w",
+        "--workers",
         type=int,
         default=CPUS_COUNT,
-        help="Number of workers in the pool.")
-    ap.add_argument('blendfile', help="Blender project file to render.")
+        help="Number of workers in the pool.",
+    )
+    ap.add_argument("blendfile", help="Blender project file to render.")
 
     args = ap.parse_args()
     args.blendfile = os.path.abspath(args.blendfile)
     return args
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     """
     The Main Function Of The Program
     """
 
     print()
-    
+
     args = parse_arguments()
 
     frame_start, frame_end, render_path = get_project_info(args.blendfile)
 
     render_setting = (args.blendfile, args.workers)
-    
-    render_multiprocess(render_setting, frame_start,frame_end, render_path)
+
+    render_multiprocess(render_setting, frame_start, frame_end, render_path)
 
     join_parts(render_path)

--- a/scripts/render_video_multithreaded_script.py
+++ b/scripts/render_video_multithreaded_script.py
@@ -1,6 +1,0 @@
-import bpy
-
-scene = bpy.context.scene
-print("START %d" % (scene.frame_start))
-print("END %d" % (scene.frame_end))
-print("RENDERPATH %s" % (scene.render.filepath))


### PR DESCRIPTION
closes https://github.com/GDquest/Blender-power-sequencer/issues/143

some notes:
- very much untested in a sense, since I don't edit videos
    - might need to tweak / change the behavior a bit to match how a video editor would use it
- renders to //render, and only to //render
- removes all the other options, will add them back if they are useful
- only minimal progress output
- ctl-c now works an kills blender, but spews ugly message
- how to cleanup to parts (kind of going back to not knowing how a video editor would use this)
