### PR TITLE
Proxy options

### DIFF
--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -58,6 +58,9 @@ class Video(Media):
 
     def __init__(self, path_source, **kwargs):
         super().__init__(path_source, **kwargs)
+        if "codec" not in self.options:
+            self.options["codec"] = "mpeg2video"
+
         self.path_proxy = self.get_path_proxy(self.path_source)
         self.frame_count = self.get_frame_count(self.path_source)
         self.proxy_command = self.get_proxy_command(self.path_source,
@@ -105,7 +108,7 @@ class Video(Media):
             "-sn",
             "-an",
             "-c:v",
-            "mpeg2video",
+            self.options["codec"],
             "-b:v",
             "1800k",
             "-filter:v",

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -156,7 +156,7 @@ class Image(Media):
     ]
 
     def __init__(self, path_source):
-        self.path_source = path_source
+        super().__init__(path_source)
         self.path_proxy = self.get_path_proxy(self.path_source)
         self.proxy_command = self.get_proxy_command(self.path_source,
                                                     self.path_proxy)

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -60,6 +60,8 @@ class Video(Media):
         super().__init__(path_source, **kwargs)
         if "codec" not in self.options:
             self.options["codec"] = "mpeg2video"
+        if "bitrate" not in self.options:
+            self.options["bitrate"] = "1800k"
 
         self.path_proxy = self.get_path_proxy(self.path_source)
         self.frame_count = self.get_frame_count(self.path_source)
@@ -110,7 +112,7 @@ class Video(Media):
             "-c:v",
             self.options["codec"],
             "-b:v",
-            "1800k",
+            self.options["bitrate"],
             "-filter:v",
             "scale=iw*{size}:ih*{size}".format(size = self.options["size"]/100),
             "-y",

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -51,38 +51,6 @@ class Video(Media):
     Represents a video
     """
     EXTENSIONS = [".mp4", ".mkv", ".mov", ".flv"]
-    PROXY_COMMAND_TEMPLATE = [
-        "ffmpeg",
-        "-i",
-        "",
-        "-v",
-        "quiet",
-        "-stats",
-        "-f",
-        "matroska",
-        "-sn",
-        "-an",
-        "-c:v",
-        "mpeg2video",
-        "-b:v",
-        "1800k",
-        "-filter:v",
-        "scale=iw*0.25:ih*0.25",
-        "-y",
-        "",
-    ]
-    FFPROBE_COMMAND_TEMPLATE = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=nb_frames",
-        "-of",
-        "default=noprint_wrappers=1:nokey=1",
-        "",
-    ]
 
     def __init__(self, path_source):
         super().__init__(path_source)
@@ -95,8 +63,18 @@ class Video(Media):
         """
         takes in path to file, returns the number of frames in the video
         """
-        ffprobe_frame_cmd = [arg for arg in self.FFPROBE_COMMAND_TEMPLATE]
-        ffprobe_frame_cmd[-1] = path
+        ffprobe_frame_cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=nb_frames",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            path,
+        ]
         return int(subprocess.check_output(ffprobe_frame_cmd).decode())
 
     def get_path_proxy(self, path):
@@ -110,9 +88,26 @@ class Video(Media):
         """
         takes in path to file, returns the command for generating the proxy
         """
-        proxy_cmd = [arg for arg in self.PROXY_COMMAND_TEMPLATE]
-        proxy_cmd[2] = path_source
-        proxy_cmd[-1] = path_proxy
+        proxy_cmd = [
+            "ffmpeg",
+            "-i",
+            path_source,
+            "-v",
+            "quiet",
+            "-stats",
+            "-f",
+            "matroska",
+            "-sn",
+            "-an",
+            "-c:v",
+            "mpeg2video",
+            "-b:v",
+            "1800k",
+            "-filter:v",
+            "scale=iw*0.25:ih*0.25",
+            "-y",
+            path_proxy,
+        ]
         return proxy_cmd
 
     def create_proxy_file(self):
@@ -140,20 +135,6 @@ class Image(Media):
     """
 
     EXTENSIONS = [".png", ".jpg", ".jpeg"]
-    PROXY_COMMAND_TEMPLATE = [
-        "ffmpeg",
-        "-i",
-        "",
-        "-v",
-        "quiet",
-        "-stats",
-        "-vf",
-        "scale=iw*0.25:ih*0.25",
-        "-f",
-        "apng",
-        "-y",
-        "",
-    ]
 
     def __init__(self, path_source):
         super().__init__(path_source)
@@ -172,9 +153,20 @@ class Image(Media):
         """
         takes in path to file, returns the command for generating the proxy
         """
-        proxy_cmd = [arg for arg in self.PROXY_COMMAND_TEMPLATE]
-        proxy_cmd[2] = path_source
-        proxy_cmd[-1] = path_proxy
+        proxy_cmd = [
+            "ffmpeg",
+            "-i",
+            path_source,
+            "-v",
+            "quiet",
+            "-stats",
+            "-f",
+            "apng",
+            "-filter:v",
+            "scale=iw*0.25:ih*0.25",
+            "-y",
+            path_proxy,
+        ]
         return proxy_cmd
 
 


### PR DESCRIPTION
This makes some parameters (size, codec, bitrate) of the proxies to generate configurable (see #174). These options aren't currently accessible from the outside as I was not sure what interface for the user we are aiming for – a set of sensible presets or access to the bare parameters?

In the current state, the script will do exactly the same as before, i.e. create 25% proxies with 1800kbps MPEG2 for video. However, if, for example, you change the options dictionary in the main function to
```python
options = { "size": 50, "codec": "mjpeg", "bitrate": "10M" }
```
the script will generate 50% proxies with 10Mbps MJPEG for video. Note that the `bitrate` option currently is just a string that is directly passed to ffmpeg instead of a proper number.

As an implementation detail, I got rid of the command templates and just moved them to the respective functions that return or use these commands. This way, the construction of the arguments array to me seems to be more comprehensible as one doesn't have to fiddle with array indices.