### PR TITLE
Fixed 2 issues in swap_strips operator

### DIFF
--- a/operators/swap_strips.py
+++ b/operators/swap_strips.py
@@ -47,7 +47,7 @@ class SwapStrips(bpy.types.Operator):
         small_strip_start, big_strip_start  = small_strip.frame_final_start, big_strip.frame_final_start
 
         end_frame += big_strip.frame_final_duration - \
-            small_strip.frame_final_duration
+                small_strip.frame_final_duration
         
         # Move both strips to an empty location, otherwise they'll collide upon moving
         self.move_to_frame(small_strip, end_frame)

--- a/operators/swap_strips.py
+++ b/operators/swap_strips.py
@@ -46,6 +46,9 @@ class SwapStrips(bpy.types.Operator):
         end_frame = max(bpy.context.sequences, key=attrgetter('frame_final_end')).frame_final_end
         small_strip_start, big_strip_start  = small_strip.frame_final_start, big_strip.frame_final_start
 
+        end_frame += big_strip.frame_final_duration - \
+            small_strip.frame_final_duration
+        
         # Move both strips to an empty location, otherwise they'll collide upon moving
         self.move_to_frame(small_strip, end_frame)
         self.move_to_frame(big_strip, end_frame + small_strip.frame_final_duration + 1)

--- a/operators/swap_strips.py
+++ b/operators/swap_strips.py
@@ -35,7 +35,7 @@ class SwapStrips(bpy.types.Operator):
             for s in other_sequences:
                 if s.channel != small_strip.channel:
                     continue
-                if s.frame_final_end < small_strip.frame_final_start:
+                if s.frame_final_end <= small_strip.frame_final_start:
                     continue
 
                 if s.frame_final_start < small_strip.frame_final_start + \


### PR DESCRIPTION
- Issue 1: Trying to swap 2 strips at the same channel, with the strictly shorter in duration strip at the right, and if: end_frame - small_strip.frame_final_start < big_strip.frame_final_duration, would result in the big_strip landing in an incorrect location.
Adding the amount: big_strip.frame_final_duration - small_strip.frame_final_duration to the end frame, makes the condition: end_frame - small_strip.frame_final_start < big_strip.frame_final_duration always false.

- Issue 2: When the strictly small_strip is connected at the left with another strip, the swap wouldn't take place, even if it was possible.