### PR TITLE
Refactor proxy script's argument parsing

### DIFF
--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -185,8 +185,8 @@ def get_path_from_command_line():
         if os.path.exists(path_from_args):
             if os.path.isdir(path_from_args):
                 path = path_from_args
-            elif os.path.isfile(path_from_args) and path.endswith(".blend"):
-                path = os.path.split(path)[0]
+            elif os.path.isfile(path_from_args) and path_from_args.endswith(".blend"):
+                path = os.path.dirname(path_from_args)
     return path
 
 

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -8,7 +8,6 @@ class Media:
     """
     Base interface to generate proxies from with ffmpeg
     """
-    EXTENSIONS = ["test"]
 
     def __init__(self, path_source, **kwargs):
         self.path_source = path_source

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -210,10 +210,11 @@ def get_media_file_paths(working_dir, ignored_dirs=["BL_proxy"]):
                 file_paths.append(os.path.join(dirpath, f))
     return file_paths
 
+OPTIONS_PRESETS = dict()
 
 if __name__ == "__main__":
     """
-    1) Parse arguments to get the working directory
+    1) Parse arguments to get the working directory and encoding presets
     2) Find video and image files and create a Media object for each of them
     3) create proxy
         - create path
@@ -223,6 +224,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create proxies for Blender VSE using FFMPEG.")
     parser.add_argument("working_directory", nargs="?",
                         help="The directory containing media to create proxies for")
+    parser.add_argument("-p", "--preset", help="A preset name for proxy encoding",
+                        choices=[])
     args = parser.parse_args()
 
     working_dir = "."
@@ -230,7 +233,10 @@ if __name__ == "__main__":
         working_dir = get_working_directory(args.working_directory)
 
     media_file_paths = get_media_file_paths(working_dir)
+
     options = dict()
+    if args.preset:
+        options = OPTIONS_PRESETS[args.preset]
 
     media_objects = []
     for path in media_file_paths:

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -178,7 +178,7 @@ def get_working_directory(path):
     """
     If path is an actually directory its absolute path is returned. If it is a
     .blend file the absolute path to the containing directory is returned. In
-    all other cases the current directory is returned.
+    all other cases an exception is raised.
     """
     abs_path = os.path.abspath(path)
     if os.path.exists(abs_path):
@@ -186,7 +186,7 @@ def get_working_directory(path):
             return abs_path
         elif os.path.isfile(abs_path) and abs_path.endswith(".blend"):
             return os.path.dirname(abs_path)
-    return "."
+    raise ValueError("{} is neither a directory nor a .blend file".format(path))
 
 def get_media_file_paths(working_dir, ignored_dirs=["BL_proxy"]):
     """

--- a/scripts/build_ffmpeg_proxies.py
+++ b/scripts/build_ffmpeg_proxies.py
@@ -8,14 +8,6 @@ class Media:
     Base interface to generate proxies from with ffmpeg
     """
     EXTENSIONS = ["test"]
-    PROXY_COMMAND_TEMPLATE = [
-        "ffmpeg",
-        "-i",
-        "",
-        "-v",
-        "quiet",
-        "-stats",
-    ]
 
     def __init__(self, path_source, **kwargs):
         self.path_source = path_source


### PR DESCRIPTION
This uses `argparse` to implement the command-line interface for `build_ffmpeg_proxies.py` and adds a bogus `-p/--preset` option that can be used in the future to implement different presets for the proxy generation (see #184). For example, to add an preset for 50% MJPEG (5Mbps) proxies one could set
```python
OPTIONS_PRESETS = {"mjpeg": {"size": 50, "codec": "mjpeg", "bitrate": "12M" }}
```
and add `"mjpeg"` to the `choices` array in the definition of the `-p/--preset` argument.

This changes the behaviour of the script when an invalid path is passed. Currently, the current directory is used in that case, now it throws an exception. In principle, this is a breaking change. However, I (and I suppose others too) would prefer the script telling me that the path I have given to it is invalid and doing nothing than it doing work in a directory I most probably did not intend it to work in.

I also removed the `EXTENSIONS` and `PROXY_COMMAND_TEMPLATE` variables from the `Base` class as they seemingly aren't used anywhere.