### PR TITLE
Added operator to deselect strips - time cursor 

### DIFF
--- a/operators/deselect_semi_timeline.py
+++ b/operators/deselect_semi_timeline.py
@@ -41,12 +41,12 @@ class DeselectSemiTimeline(bpy.types.Operator):
     
     def strip_frame(self, strip, at_left, strategy=2):
         """
-        Represents a strips by a frame, using various strategies, based on the
+        Represents a strip by a frame, using various strategies, based on the
         region the strip lies.
         Args:
         - strip: The strip to extract a frame representation of it.
-        - at_left: True, to indicate that the strip lies at the left of the
-                       time cursor, or False for right of the time cursor.
+        - at_left: True, to indicate that the mouse lies at the left of the
+                   time cursor, or False for right of the time cursor.
         - strategy: The strategy number to be used in the frame representation
                     of the strip. 1 to use the frame_final_end if at_left is 
                     True or to use frame_final_start if at_left is False.

--- a/operators/deselect_semi_timeline.py
+++ b/operators/deselect_semi_timeline.py
@@ -1,0 +1,63 @@
+import bpy
+import operator
+
+class DeselectSemiTimeline(bpy.types.Operator):
+    """
+    Deselects all the strips at the left or right of the time cursor, based 
+    on the position of the mouse.
+    """
+    bl_idname = "power_sequencer.deselect_semi_timeline"
+    bl_label = "Deselect Semi Timeline"
+    bl_description = """Deselects all the strips at the left or right of the 
+                        time cursor, based on the position of the mouse."""
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return len(bpy.context.selected_sequences) > 0
+
+    def invoke(self, context, event):
+        time_cursor = context.scene.frame_current
+        left_region = self.is_mouse_left(context, event)
+        comp = operator.lt if left_region else operator.gt
+        for s in context.sequences:
+            if comp(self.strip_frame(s, left_region), time_cursor):
+                s.select = False
+
+        return {'FINISHED'}
+    
+    def is_mouse_left(self, context, event):
+        """
+        Indicates if the mouse in at the left of the time cursor.
+        Returns True if the mouse is at the left of the time cursor, otherwise 
+        False.
+        """
+        
+        view2d = context.region.view2d
+        time_cursor_x = view2d.view_to_region(context.scene.frame_current, 1)[0]
+        mouse_x = event.mouse_region_x
+        
+        return time_cursor_x - mouse_x > 0
+    
+    def strip_frame(self, strip, at_left, strategy=2):
+        """
+        Represents a strips by a frame, using various strategies, based on the
+        region the strip lies.
+        Args:
+        - strip: The strip to extract a frame representation of it.
+        - at_left: True, to indicate that the strip lies at the left of the
+                       time cursor, or False for right of the time cursor.
+        - strategy: The strategy number to be used in the frame representation
+                    of the strip. 1 to use the frame_final_end if at_left is 
+                    True or to use frame_final_start if at_left is False.
+                    Defaults to 2.
+        Returns The frame representation of the strip.
+        """
+    
+        if 1 == strategy:
+            return strip.frame_final_end if at_left else strip.frame_final_start
+        elif 2 == strategy:
+            return int((strip.frame_final_start + strip.frame_final_end) / 2)
+        else:
+            #Default, in case strategy number is not in the list
+            return int((strip.frame_final_start + strip.frame_final_end) / 2)


### PR DESCRIPTION
Added operator: deselect_semi_timeline.py,  to deselect all the strips at the left or right of the time cursor, based on the position of the mouse (see #182). The operator uses a module: strip_frame to recognize if a strip lies at the left or at the right of the time cursor. This module uses a strategy to define when a strip lies at the left or right of the time cursor. The strategy can be changed in the future, by parsing a different number in the module's arguments at call. By default, the average frame from the beginning and ending of the strip was used. There is 1 more strategy available (see source code).