### PR TITLE
Changed select_related_strips.py

### DIFF
--- a/operators/select_related_strips.py
+++ b/operators/select_related_strips.py
@@ -61,9 +61,9 @@ class SelectRelatedStrips(bpy.types.Operator):
         bpy.ops.sequencer.select_all(action='DESELECT')
         strip.select = True
         bpy.ops.transform.seq_slide(value=(0, 0))
+        strip.select = False
         for s in context.selected_sequences:
-            if s != strip:
-                neighbours.append(s)
+            neighbours.append(s)
                 
         try:
             neighbours.append(strip.input_1)

--- a/operators/select_related_strips.py
+++ b/operators/select_related_strips.py
@@ -1,5 +1,5 @@
 import bpy
-from .utils.global_settings import SequenceTypes
+from operator import attrgetter
 
 class SelectRelatedStrips(bpy.types.Operator):
     """
@@ -9,7 +9,7 @@ class SelectRelatedStrips(bpy.types.Operator):
     """
     bl_idname = 'power_sequencer.select_related_strips'
     bl_label = 'Select Related Strips'
-    bl_description = "Find and select effect strips applied to selected strips"
+    bl_description = "Find and select all strips related to the selection"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -17,53 +17,62 @@ class SelectRelatedStrips(bpy.types.Operator):
         return len(context.selected_sequences) > 0
 
     def execute(self, context):
-        effects = [s for s in context.sequences
-                   if s.type in SequenceTypes.EFFECT]
-        found_effects = self.find_related_effects(context.selected_sequences, effects)
-        effects_to_select = list(found_effects)
-        while len(found_effects) > 0:
-            found_effects = self.find_related_effects(found_effects, effects)
-            effects_to_select.extend(found_effects)
-
-        for e in effects_to_select:
-            e.select = True
-
-        # found_inputs = self.find_related_inputs(context.selected_sequences, effects)
-        # inputs_to_select = list(found_inputs)
-        # while len(found_inputs) > 0:
-        #     found_inputs = self.find_related_inputs(found_inputs)
-        #     inputs_to_select.extend(found_inputs)
-
-        # for i in inputs_to_select:
-        #     i.select = True
+        related_strips = set()
+        for s in context.selected_sequences:
+            self.dfs(related_strips, s, context)
+            
+        for s in related_strips:
+            s.select = True
+        
         return {'FINISHED'}
-
-    def find_related_effects(self, sequences, effects):
-        found = []
-        for s in sequences:
-            for e in effects:
-                try:
-                    if e.input_1 == s:
-                        found.append(e)
-                except Exception:
-                    continue
-                try:
-                    if e.input_2 == s:
-                        found.append(e)
-                except Exception:
-                    continue
-        return found
-
-    # Won't work: you need to only select inputs related to the starting selection
-    # def find_related_inputs(self, sequences, effects):
-    #     found_inputs = []
-    #     for e in effects:
-    #         try:
-    #             found_inputs.append(e.input_1)
-    #         except Exception:
-    #             pass
-    #         try:
-    #             found_inputs.append(e.input_2)
-    #         except Exception:
-    #             pass
-    #     return found_inputs
+    
+    def dfs(self, visited, strip, context):
+        """
+        Performs a depth first search traversal to the graph of strips, to find
+        all related strips.
+        Args:
+        - visited: A set with all the strips that have been visited.
+        - strip: The strip to start the search from.
+        """
+        visited.add(strip)
+        neighbours = self.find_neighbours(strip, context)
+        for s in neighbours:
+            if s not in visited:
+                self.dfs(visited, s, context)
+    
+    def find_neighbours(self, strip, context):
+        """
+        Strips and their effect strips define a graph, where each node is a 
+        strip and edges are their connections. It finds all the neighbours of a 
+        strip in the graph, and *sometimes neighbours of neighbours and so on*.
+        *In order to find the neighbours of a strip the 
+        bpy.ops.transform.seq_slide operator is used, and usually finds many
+        levels of neighbours, but always finds the first level, which is needed,
+        the other levels are redundant, but are included for brevity reasons. 
+        Args:
+        - strip: The strip to find all its neighbours.
+        Returns: A list with all the neighbours of the strip and sometimes 
+                 neighbours of neighbours and so on.
+        """
+        #Respects initial selection
+        init_selected_strips = [s for s in context.selected_sequences]
+        
+        neighbours = []
+        bpy.ops.sequencer.select_all(action='DESELECT')
+        strip.select = True
+        bpy.ops.transform.seq_slide(value=(0, 0))
+        for s in context.selected_sequences:
+            if s != strip:
+                neighbours.append(s)
+                
+        try:
+            neighbours.append(strip.input_1)
+            neighbours.append(strip.input_2)
+        except Exception:
+            pass
+        
+        bpy.ops.sequencer.select_all(action='DESELECT')
+        for s in init_selected_strips:
+            s.select = True
+            
+        return neighbours


### PR DESCRIPTION
The operator now selects all related strips to the selection. It also works with effect strips as the initial selection, with chains of effects on effects and effects with 2 inputs (i.e. cross).

How it works: Strips and its effects define a graph (we can consider it as an undirected one). Every strip is a node, while an edge is the connection of a strip with its effect (i.e. base_strip -> effect_strip, '->' is the edge, while base_strip and effect_strip the nodes). Using the bpy.ops.transform.seq_slide operator and with the input strips of the effects we can find all the neightbours of a strip in the graph, so we can apply a Depth First Search traversal to find all the related strips.

*Note for method find_neighbours: As stated in its documentation, it finds more neighbours than asked, but because extra code is needed to filter those, for brevity I permited that. The algorithm stays correct even with this behavior, the extra neighbours find_neighbours finds, are at most redundant. As of the performance in total, it is not clear if this behaviour of find_neighbours adds overhead or makes the algorithm faster, of course all that by a constant factor, the space and time complexities stay the same in both cases (not that it matters anyway).

An extreme case (for fun):
We only select the cross effect (everything is related).

![pre related strips](https://user-images.githubusercontent.com/42165833/45156053-ab0a3480-b1e5-11e8-81d9-9f6b4b75d776.png)

It selects everything related. For every other selected strip there is a path of effects and relation to the initial selection.

![post related strips](https://user-images.githubusercontent.com/42165833/45156094-d4c35b80-b1e5-11e8-8f0b-80e575bcaaa7.png)

Of course it works with multiple selections too.