### PR TITLE
Cleanup keymaps properly

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,28 +79,26 @@ def register():
 
     keymaps = register_shortcuts()
     addon_keymaps += keymaps
-    print(addon_keymaps)
 
     bpy.types.Scene.power_sequencer = bpy.props.PointerProperty(
         type=PowerSequencerProperties)
 
     handlers_register()
-    print("Registered {} with {} modules".format(bl_info["name"], len(
-        modules)))
+    print("Registered {} with {} modules".format(bl_info["name"], len(modules)))
 
 
 def unregister():
     global addon_keymaps
     addon_updater_ops.unregister()
 
-    wm = bpy.context.window_manager
-    for km in addon_keymaps:
-        wm.keyconfigs.addon.keymaps.remove(km)
+    for km, kmi in addon_keymaps:
+        km.keymap_items.remove(kmi)
+    addon_keymaps.clear()
 
+    handlers_unregister()
     try:
         bpy.utils.unregister_module(__name__)
     except:
         traceback.print_exc()
-
-    handlers_unregister()
     print("Unregistered {}".format(bl_info["name"]))
+

--- a/utils/register_shortcuts.py
+++ b/utils/register_shortcuts.py
@@ -38,11 +38,11 @@ def register_shortcuts():
     wm = bpy.context.window_manager
     for name, group in os:
         km = wm.keyconfigs.addon.keymaps.new(name=name, space_type=keymaps_meta[name])
-        kms.append(km)
         for bl_idname, d in group:
             for s in d['shortcuts']:
                 kmi = km.keymap_items.new(bl_idname, **s[0])
                 for pn, pv in s[1].items():
                     set_keymap_property(kmi.properties, pn, pv)
+                kms.append((km, kmi))
     return kms
 


### PR DESCRIPTION
In the blender manual there's a bit of a different way to remove the keymaps upon unregistering the module which seems to make more sense :). Minor change - doesn't fix the unregister errors (#269), but it does clean up the keymaps now. I think the unregister errors are caused by the order in which we register the operators (because there's inter-dependencies)