### PR TITLE
Add SelectLinkedStrips operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -49,6 +49,7 @@ from .save_direct import SaveDirect
 from .scene_create_from_selection import SceneCreateFromSelection
 from .scene_cycle import SceneCycle
 from .select_closest_to_mouse import SelectClosestToMouse
+from .select_linked_strips import SelectLinkedStrips
 from .select_linked_effect import SelectLinkedEffect
 from .select_related_strips import SelectRelatedStrips
 from .select_strips_under_cursor import SelectStripsUnderCursor

--- a/operators/select_linked_strips.py
+++ b/operators/select_linked_strips.py
@@ -1,0 +1,56 @@
+import bpy
+
+from .utils.doc import doc_name, doc_idname, doc_brief, doc_description
+
+
+class SelectLinkedStrips(bpy.types.Operator):
+    """
+    Add/Remove linked strips near mouse poitner to/from selection without the need to
+    previously have clicked/manually selected
+    """
+    doc = {
+        'name': doc_name(__qualname__),
+        'demo': '',
+        'description': doc_description(__doc__),
+        'shortcuts': [
+            ({'type': 'L', 'value': 'PRESS'}, {}, 'Add/Remove Linked to/from Selection')
+        ],
+        'keymap': 'Sequencer'
+    }
+    bl_idname = doc_idname(doc['name'])
+    bl_label = doc['name']
+    bl_description = doc_brief(doc['description'])
+    bl_options = {'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.sequence_editor is not None
+
+    def execute(self, context):
+        # save current selection first
+        selection = set(context.selected_sequences)
+
+        # if previously selected strips are linked select links as well to toggle them too
+        bpy.ops.sequencer.select_linked()
+        selection_new = set(context.selected_sequences).difference(selection)
+        # deselect & select only the linked strips near mouse pointer
+        bpy.ops.sequencer.select_all(action='DESELECT')
+        # re-enable linked + add selection near mouse pointer
+        for s in selection_new:
+            s.select = True
+        bpy.ops.sequencer.select_linked()
+        bpy.ops.sequencer.select_linked_pick('INVOKE_DEFAULT', extend=True)
+        selection_new = set(context.selected_sequences)
+
+        # identify if linked strips under mouse pointer need to be added or removed
+        action = len(selection.intersection(selection_new)) != len(selection_new)
+
+        # re-enable previous selection
+        for s in selection:
+            s.select = True
+
+        # take care of toggle for strips under mouse
+        for s in selection_new:
+            s.select = action
+        return {'FINISHED'}
+


### PR DESCRIPTION
It works via `L` shortcut and it adds/removes linked strips near mouse
pointer to current selection (eg. toggle + add selection of linked strips to
current selection - doesn't need `F6` interaction)

closes #251 
closes #252 (if this was because first proposal from #251 used `L` & `Shift L`)