### PR TITLE
Fix wrong bpy.context use in operator functions

### DIFF
--- a/operators/add_speed.py
+++ b/operators/add_speed.py
@@ -44,13 +44,13 @@ class AddSpeed(bpy.types.Operator):
 
     def execute(self, context):
         sequencer = bpy.ops.sequencer
-        scene = bpy.context.scene
+        scene = context.scene
         active = scene.sequence_editor.active_strip
 
         # Select linked sequences
-        for s in find_linked(bpy.context.selected_sequences):
+        for s in find_linked(context, context.sequences, context.selected_sequences):
             s.select = True
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
 
         video_sequences = [
             s for s in selection if s.type in SequenceTypes.VIDEO
@@ -75,7 +75,7 @@ class AddSpeed(bpy.types.Operator):
                     return {'CANCELLED'}
             selection_blocks = [[s] for s in video_sequences]
         else:
-            selection_blocks = slice_selection(selection)
+            selection_blocks = slice_selection(context, selection)
 
         for block in selection_blocks:
             # start, end = 0, 0
@@ -95,7 +95,7 @@ class AddSpeed(bpy.types.Operator):
                 active = scene.sequence_editor.active_strip
             # Add speed effect
             sequencer.effect_strip_add(type='SPEED')
-            effect_strip = bpy.context.scene.sequence_editor.active_strip
+            effect_strip = context.scene.sequence_editor.active_strip
             effect_strip.use_default_fade = False
             effect_strip.speed_factor = self.speed_factor
 
@@ -113,8 +113,10 @@ class AddSpeed(bpy.types.Operator):
 
             effect_strip.select = True
             sequencer.meta_make()
-            bpy.context.selected_sequences[
-                0].name = source_name + " " + str(self.speed_factor) + 'x'
+            context.selected_sequences[0].name = (source_name
+                                                  + " "
+                                                  + str(self.speed_factor)
+                                                  + 'x')
         self.report({"INFO"}, "Successfully processed " +
                     str(len(selection_blocks)) + " selection blocks")
         return {"FINISHED"}

--- a/operators/add_transform.py
+++ b/operators/add_transform.py
@@ -38,10 +38,10 @@ class AddTransform(bpy.types.Operator):
 
     def execute(self, context):
         sequencer = bpy.ops.sequencer
-        sequence_editor = bpy.context.scene.sequence_editor
-        render = bpy.context.scene.render
+        sequence_editor = context.scene.sequence_editor
+        render = context.scene.render
 
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         selection = [s for s in selection if s.type in ('IMAGE', 'MOVIE')]
         if not selection:
             self.report({"ERROR_INVALID_INPUT"},

--- a/operators/align_audios.py
+++ b/operators/align_audios.py
@@ -35,7 +35,7 @@ class AlignAudios(bpy.types.Operator):
         scene = context.scene
         if scene.sequence_editor and scene.sequence_editor.active_strip:
             active = scene.sequence_editor.active_strip
-            selected = bpy.context.selected_sequences
+            selected = context.selected_sequences
 
             if len(selected) == 2 and active in selected:
                 selected.pop(selected.index(active))
@@ -64,7 +64,7 @@ class AlignAudios(bpy.types.Operator):
         active = scene.sequence_editor.active_strip
         active_filepath = bpy.path.abspath(active.sound.filepath)
 
-        selected = bpy.context.selected_sequences
+        selected = context.selected_sequences
         selected.pop(selected.index(active))
 
         align_strip = selected[0]

--- a/operators/border_select.py
+++ b/operators/border_select.py
@@ -36,7 +36,7 @@ class BorderSelect(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        for s in bpy.context.selected_sequences:
+        for s in context.selected_sequences:
             s.select_right_handle = False
             s.select_left_handle = False
         bpy.ops.sequencer.select_border('INVOKE_DEFAULT', extend=self.extend)

--- a/operators/change_playback_speed.py
+++ b/operators/change_playback_speed.py
@@ -37,6 +37,6 @@ class ChangePlaybackSpeed(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        bpy.context.scene.power_sequencer.playback_speed = self.speed
+        context.scene.power_sequencer.playback_speed = self.speed
         return {"FINISHED"}
 

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -39,7 +39,7 @@ class ChannelOffset(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         if not selection:
             return {'CANCELLED'}
 

--- a/operators/concatenate_strips.py
+++ b/operators/concatenate_strips.py
@@ -7,11 +7,11 @@ from .utils.get_mouse_view_coords import get_mouse_frame_and_channel
 from .utils.doc import doc_name, doc_idname, doc_brief, doc_description
 
 
-def find_sequences_before(strip):
+def find_sequences_before(context, strip):
     """
     Returns a list of sequences that are before the strip in the current context
     """
-    return [s for s in bpy.context.sequences
+    return [s for s in context.sequences
             if s.frame_final_end <= strip.frame_final_start]
 
 
@@ -73,7 +73,7 @@ class ConcatenateStrips(bpy.types.Operator):
         return True
 
     def invoke(self, context, event):
-        frame, channel = get_mouse_frame_and_channel(event)
+        frame, channel = get_mouse_frame_and_channel(context, event)
         if not context.selected_sequences:
             bpy.ops.power_sequencer.select_closest_to_mouse(
                 frame=frame, channel=channel)
@@ -89,10 +89,10 @@ class ConcatenateStrips(bpy.types.Operator):
         if len(channels) == len(selection):
             for s in selection:
                 if self.direction == 'right':
-                    in_channel = [strip for strip in find_sequences_before(s)
+                    in_channel = [strip for strip in find_sequences_before(context, s)
                                   if strip.channel == s.channel]
                 else:
-                    in_channel = [strip for strip in find_sequences_after(s)
+                    in_channel = [strip for strip in find_sequences_after(context, s)
                                   if strip.channel == s.channel]
                 in_channel.append(s)
                 to_concatenate = [strip for strip in in_channel

--- a/operators/copy_selected_sequences.py
+++ b/operators/copy_selected_sequences.py
@@ -43,11 +43,11 @@ class CopySelectedSequences(bpy.types.Operator):
         return context.selected_sequences
 
     def execute(self, context):
-        cursor_start_frame = bpy.context.scene.frame_current
+        cursor_start_frame = context.scene.frame_current
         sequencer = bpy.ops.sequencer
 
         # Deactivate audio playback and video preview
-        scene = bpy.context.scene
+        scene = context.scene
         initial_audio_setting = scene.use_audio_scrub
         initial_proxy_size = context.space_data.proxy_render_size
         scene.use_audio_scrub = False
@@ -55,9 +55,9 @@ class CopySelectedSequences(bpy.types.Operator):
 
         first_sequence = min(context.selection,
                              key=attrgetter('frame_final_start'))
-        bpy.context.scene.frame_current = first_sequence.frame_final_start
+        context.scene.frame_current = first_sequence.frame_final_start
         sequencer.copy()
-        bpy.context.scene.frame_current = cursor_start_frame
+        context.scene.frame_current = cursor_start_frame
 
         scene.use_audio_scrub = initial_audio_setting
         context.space_data.proxy_render_size = initial_proxy_size

--- a/operators/crossfade_add.py
+++ b/operators/crossfade_add.py
@@ -54,7 +54,7 @@ class CrossfadeAdd(bpy.types.Operator):
         sorted_selection = sorted(context.selected_sequences,
                                   key=attrgetter('frame_final_start'))
         for selected_strip in sorted_selection:
-            next_in_channel = [s for s in find_sequences_after(selected_strip)
+            next_in_channel = [s for s in find_sequences_after(context, selected_strip)
                                if s.channel == selected_strip.channel]
             if not next_in_channel:
                 continue
@@ -76,13 +76,13 @@ class CrossfadeAdd(bpy.types.Operator):
                 next_sequence.frame_final_start += crossfade_length / 2
                 selected_strip.frame_final_end -= crossfade_length / 2
 
-            self.apply_crossfade(selected_strip, next_sequence)
+            self.apply_crossfade(context, selected_strip, next_sequence)
         return {"FINISHED"}
 
-    def apply_crossfade(self, strip_from, strip_to):
+    def apply_crossfade(self, context, strip_from, strip_to):
         bpy.ops.sequencer.select_all(action='DESELECT')
         strip_from.select = True
         strip_to.select = True
-        bpy.context.scene.sequence_editor.active_strip = strip_to
+        context.scene.sequence_editor.active_strip = strip_to
         bpy.ops.sequencer.effect_strip_add(type='GAMMA_CROSS')
 

--- a/operators/crossfade_edit.py
+++ b/operators/crossfade_edit.py
@@ -38,7 +38,7 @@ class CrossfadeEdit(bpy.types.Operator):
     def execute(self, context):
         active = context.scene.sequence_editor.active_strip
         if active.type not in self.crossfade_types:
-            effect = self.find_cross_effect(active)
+            effect = self.find_cross_effect(context, active)
             if not effect:
                 return {"CANCELLED"}
             active = context.scene.sequence_editor.active_strip = effect
@@ -61,7 +61,7 @@ class CrossfadeEdit(bpy.types.Operator):
         if sequence.type not in SequenceTypes.VIDEO + SequenceTypes.IMAGE:
             return
 
-        effect_sequences = (s for s in bpy.context.sequences
+        effect_sequences = (s for s in context.sequences
                             if s.type in SequenceTypes.EFFECT)
         found_effect_strips = []
         for s in effect_sequences:

--- a/operators/crossfade_remove.py
+++ b/operators/crossfade_remove.py
@@ -31,7 +31,7 @@ class CrossfadeRemove(bpy.types.Operator):
     def execute(self, context):
         to_process = (self.sequences_override
                       if self.sequences_override else
-                      bpy.context.selected_sequences)
+                      context.selected_sequences)
         sequences = [s for s in to_process
                      if s.type in SequenceTypes.TRANSITION]
         if not sequences:

--- a/operators/delete_direct.py
+++ b/operators/delete_direct.py
@@ -28,14 +28,14 @@ class DeleteDirect(bpy.types.Operator):
         return len(context.sequences) > 0
 
     def invoke(self, context, event):
-        frame, channel = get_mouse_frame_and_channel(event)
+        frame, channel = get_mouse_frame_and_channel(context, event)
         if not context.selected_sequences:
             bpy.ops.power_sequencer.select_closest_to_mouse(frame=frame,
                                                             channel=channel)
         return self.execute(context)
 
     def execute(self, context):
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         if bpy.ops.power_sequencer.crossfade_remove.poll():
             bpy.ops.power_sequencer.crossfade_remove()
         bpy.ops.sequencer.delete()

--- a/operators/deselect_all_left_or_right.py
+++ b/operators/deselect_all_left_or_right.py
@@ -32,14 +32,14 @@ class DeselectAllStripsLeftOrRight(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return len(bpy.context.selected_sequences) > 0
+        return len(context.selected_sequences) > 0
 
     def invoke(self, context, event):
         frame_current = context.scene.frame_current
         frame_mouse = context.region.view2d.region_to_view(
                 event.mouse_region_x, 1)[0]
 
-        for s in bpy.context.sequences:
+        for s in context.sequences:
             if frame_mouse < frame_current or self.side == "left":
                 if s.frame_final_end < frame_current:
                     self.deselect(s)

--- a/operators/deselect_handles_and_grab.py
+++ b/operators/deselect_handles_and_grab.py
@@ -24,7 +24,7 @@ class DeselectHandlesAndGrab(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        for s in bpy.context.selected_sequences:
+        for s in context.selected_sequences:
             s.select_left_handle = False
             s.select_right_handle = False
             s.select = True

--- a/operators/duplicate_move.py
+++ b/operators/duplicate_move.py
@@ -26,10 +26,10 @@ class DuplicateMove(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return bpy.context.sequences
+        return context.sequences
 
     def invoke(self, context, event):
-        frame, channel = get_mouse_frame_and_channel(event)
+        frame, channel = get_mouse_frame_and_channel(context, event)
         if not context.selected_sequences:
             bpy.ops.power_sequencer.select_closest_to_mouse(frame=frame,
                                                             channel=channel)

--- a/operators/fade_add.py
+++ b/operators/fade_add.py
@@ -47,7 +47,7 @@ class FadeAdd(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        scene = bpy.context.scene
+        scene = context.scene
         self.fade_length = convert_duration_to_frames(self.fade_duration)
 
         # Because of the way blender updates opacity, it's best if the
@@ -60,7 +60,7 @@ class FadeAdd(bpy.types.Operator):
         last_frame = all_strips[-1].frame_final_end
         scene.frame_current = last_frame + 1
 
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         if not selection:
             return {"CANCELLED"}
 
@@ -81,15 +81,15 @@ class FadeAdd(bpy.types.Operator):
                 scene.animation_data.action = action
 
             # Create fade
-            fcurves = bpy.context.scene.animation_data.action.fcurves
+            fcurves = context.scene.animation_data.action.fcurves
 
-            self.fade_clear(s)
+            self.fade_clear(context, s)
             frame_start, frame_end = s.frame_final_start, s.frame_final_end
 
             # fade_in_frames = (frame_start, frame_start + self.fade_length)
             # fade_out_frames = (frame_end - self.fade_length, frame_end)
 
-            fade_fcurve, fade_curve_type = self.fade_find_fcurve(s)
+            fade_fcurve, fade_curve_type = self.fade_find_fcurve(context, s)
             if fade_fcurve is None:
                 fade_fcurve = fcurves.new(
                     data_path=s.path_from_id(fade_curve_type))
@@ -121,14 +121,14 @@ class FadeAdd(bpy.types.Operator):
             fade_sequence_count))
         return {"FINISHED"}
 
-    def fade_find_fcurve(self, sequence=None):
+    def fade_find_fcurve(self, context, sequence=None):
         """
         Checks if there's a fade animation on a single sequence
         If the right fcurve is found,
         volume for audio sequences and blend_alpha for other sequences,
         Returns a tuple of (fade_fcurve, fade_type)
         """
-        fcurves = bpy.context.scene.animation_data.action.fcurves
+        fcurves = context.scene.animation_data.action.fcurves
         if not sequence:
             raise AttributeError('Missing sequence parameter')
 
@@ -143,7 +143,7 @@ class FadeAdd(bpy.types.Operator):
                 break
         return fade_fcurve, fade_type
 
-    def fade_clear(self, sequence=None):
+    def fade_clear(self, context, sequence=None):
         """
         Deletes all keyframes in the blend_alpha
         or volume fcurve of the provided sequence
@@ -151,8 +151,8 @@ class FadeAdd(bpy.types.Operator):
         if not sequence:
             raise AttributeError('Missing sequence parameter')
 
-        fcurves = bpy.context.scene.animation_data.action.fcurves
-        fade_fcurve = self.fade_find_fcurve(sequence)[0]
+        fcurves = context.scene.animation_data.action.fcurves
+        fade_fcurve = self.fade_find_fcurve(context, sequence)[0]
         if fade_fcurve:
             fcurves.remove(fade_fcurve)
 

--- a/operators/grab.py
+++ b/operators/grab.py
@@ -34,17 +34,17 @@ class Grab(bpy.types.Operator):
         return context is not None
 
     def invoke(self, context, event):
-        frame, channel = get_mouse_frame_and_channel(event)
+        frame, channel = get_mouse_frame_and_channel(context, event)
         if not context.selected_sequences:
             bpy.ops.power_sequencer.select_closest_to_mouse(frame=frame,
                                                             channel=channel)
         return self.execute(context)
 
     def execute(self, context):
-        first_sequence = bpy.context.selected_sequences[0]
-        if len(bpy.context.selected_sequences) == 1 \
+        first_sequence = context.selected_sequences[0]
+        if len(context.selected_sequences) == 1 \
            and first_sequence.type in SequenceTypes.TRANSITION:
-            bpy.context.scene.sequence_editor.active_strip = first_sequence
+            context.scene.sequence_editor.active_strip = first_sequence
             return bpy.ops.power_sequencer.crossfade_edit()
         return bpy.ops.transform.seq_slide('INVOKE_DEFAULT')
 

--- a/operators/grab_closest_handle_or_cut.py
+++ b/operators/grab_closest_handle_or_cut.py
@@ -41,15 +41,15 @@ class GrabClosestCut(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return len(bpy.context.sequences) > 0
+        return len(context.sequences) > 0
 
     def invoke(self, context, event):
         sequencer = bpy.ops.sequencer
 
         mouse_x, mouse_y = event.mouse_region_x, event.mouse_region_y
-        frame, channel = self.find_cut_closest_to_mouse(mouse_x, mouse_y)
+        frame, channel = self.find_cut_closest_to_mouse(context, mouse_x, mouse_y)
 
-        matching_strips = [s for s in bpy.context.sequences
+        matching_strips = [s for s in context.sequences
                            if (abs(s.frame_final_start - frame) <= 1
                                or abs(s.frame_final_end - frame) <= 1)]
         if not self.select_linked:
@@ -60,18 +60,18 @@ class GrabClosestCut(bpy.types.Operator):
             s.select = True
         return bpy.ops.power_sequencer.grab_sequence_handles(frame=frame)
 
-    def find_cut_closest_to_mouse(self, mouse_x, mouse_y):
+    def find_cut_closest_to_mouse(self, context, mouse_x, mouse_y):
         """
         Takes the mouse's coordinates in the sequencer area and returns the two
         strips who share the cut closest to the mouse. Use it to find the
         handle(s) to select with the grab on the fly operator
         """
-        view2d = bpy.context.region.view2d
+        view2d = context.region.view2d
 
         closest_cut = (None, None)
         distance_to_closest_cut = 1000000.0
 
-        for s in bpy.context.sequences:
+        for s in context.sequences:
             channel_offset = s.channel + 0.5
             start_x, start_y = view2d.view_to_region(s.frame_final_start,
                                                      channel_offset)

--- a/operators/grab_sequence_handles.py
+++ b/operators/grab_sequence_handles.py
@@ -45,13 +45,13 @@ class GrabSequenceHandles(bpy.types.Operator):
         return self.execute(context)
 
     def execute(self, context):
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         if self.always_find_closest or not selection:
             if self.frame == -1:
                 return {'CANCELLED'}
             bpy.ops.power_sequencer.select_closest_to_mouse(
                 frame=self.frame, channel=self.channel)
-            for s in bpy.context.selected_sequences:
+            for s in context.selected_sequences:
                 self.select_closest_handle(s)
         else:
             bpy.ops.sequencer.select_all(action='DESELECT')

--- a/operators/jump_time_offset.py
+++ b/operators/jump_time_offset.py
@@ -52,7 +52,7 @@ class JumpTimeOffset(bpy.types.Operator):
     def execute(self, context):
         direction = 1 if self.direction == 'forward' else -1
         context.scene.frame_current += (
-            convert_duration_to_frames(self.duration)
+            convert_duration_to_frames(context, self.duration)
             * direction
         )
         return {'FINISHED'}

--- a/operators/jump_to_cut.py
+++ b/operators/jump_to_cut.py
@@ -36,7 +36,7 @@ class JumpToCut(bpy.types.Operator):
 
     def execute(self, context):
         jump_to_frame = None
-        frame_current = bpy.context.scene.frame_current
+        frame_current = context.scene.frame_current
         sorted_sequences = sorted(context.sequences,
                                   key=attrgetter('frame_final_start'))
         if self.direction == 'forward':
@@ -57,6 +57,6 @@ class JumpToCut(bpy.types.Operator):
                 break
 
         if jump_to_frame:
-            bpy.context.scene.frame_current = max(1, jump_to_frame)
+            context.scene.frame_current = max(1, jump_to_frame)
         return {'FINISHED'}
 

--- a/operators/make_still_image.py
+++ b/operators/make_still_image.py
@@ -39,7 +39,7 @@ class MakeStillImage(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        scene = bpy.context.scene
+        scene = context.scene
         active = scene.sequence_editor.active_strip
         sequencer = bpy.ops.sequencer
         transform = bpy.ops.transform

--- a/operators/marker_go_to_next.py
+++ b/operators/marker_go_to_next.py
@@ -31,13 +31,13 @@ class MarkerGoToNext(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        if not bpy.context.scene.timeline_markers:
+        if not context.scene.timeline_markers:
             self.report({"ERROR_INVALID_INPUT"},
                         "There are no markers. Operation cancelled.")
             return {"CANCELLED"}
 
-        frame = bpy.context.scene.frame_current
-        previous_marker, next_marker = find_neighboring_markers(frame)
+        frame = context.scene.frame_current
+        previous_marker, next_marker = find_neighboring_markers(context, frame)
 
         if not previous_marker \
            and self.target_marker == 'left' \

--- a/operators/marker_snap_to_cursor.py
+++ b/operators/marker_snap_to_cursor.py
@@ -24,7 +24,7 @@ class MarkerSnapToCursor(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        markers = bpy.context.scene.timeline_markers
+        markers = context.scene.timeline_markers
 
         selected_markers = []
         for marker in markers:
@@ -39,6 +39,6 @@ class MarkerSnapToCursor(bpy.types.Operator):
                 "You can only snap 1 marker at a time. Operation cancelled.")
             return {'CANCELLED'}
 
-        selected_markers[0].frame = bpy.context.scene.frame_current
+        selected_markers[0].frame = context.scene.frame_current
         return {'FINISHED'}
 

--- a/operators/markers_create_from_selected.py
+++ b/operators/markers_create_from_selected.py
@@ -25,14 +25,14 @@ class MarkersCreateFromSelectedStrips(bpy.types.Operator):
         return len(context.selected_sequences) > 0
 
     def execute(self, context):
-        cursor_frame_start = bpy.context.scene.frame_current
+        cursor_frame_start = context.scene.frame_current
 
         for m in context.scene.timeline_markers:
             m.select = False
 
         for s in context.selected_sequences:
             bpy.ops.marker.add()
-            new_marker = bpy.context.scene.timeline_markers[-1]
+            new_marker = context.scene.timeline_markers[-1]
 
             new_marker.select = True
             bpy.ops.marker.rename(name=s.name)

--- a/operators/meta_resize_to_content.py
+++ b/operators/meta_resize_to_content.py
@@ -26,14 +26,14 @@ class MetaResizeToContent(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         try:
-            meta = next(s for s in bpy.context.selected_sequences if s.type == 'META')
+            next(s for s in context.selected_sequences if s.type == 'META')
         except StopIteration:
             return False
         return True
 
     def execute(self, context):
-        selected_meta_strips = (s for s in bpy.context.selected_sequences if s.type == 'META')
+        selected_meta_strips = (s for s in context.selected_sequences if s.type == 'META')
         for s in selected_meta_strips:
-            s.frame_final_start, s.frame_final_end = get_frame_range(s.sequences)
+            s.frame_final_start, s.frame_final_end = get_frame_range(context, s.sequences)
         return {'FINISHED'}
 

--- a/operators/meta_separate.py
+++ b/operators/meta_separate.py
@@ -36,12 +36,12 @@ class MetaSeparateAndTrim(bpy.types.Operator):
         meta_strips = [s for s in context.selected_sequences if s.type == 'META']
         if self.trim_content:
             bpy.ops.power_sequencer.meta_trim_content_to_bounds()
-        self.separate(meta_strips)
+        self.separate(context, meta_strips)
         return {'FINISHED'}
 
-    def separate(self, meta_strips):
+    def separate(self, context, meta_strips):
         bpy.ops.sequencer.select_all(action='DESELECT')
         for m in meta_strips:
-            bpy.context.scene.sequence_editor.active_strip = m
+            context.scene.sequence_editor.active_strip = m
             bpy.ops.sequencer.meta_separate()
 

--- a/operators/mouse_space_strips.py
+++ b/operators/mouse_space_strips.py
@@ -39,7 +39,7 @@ class MouseSpaceStrips(bpy.types.Operator):
     def invoke(self, context, event):
         gap_frames = convert_duration_to_frames(self.gap_to_insert)
         strips_to_space = []
-        frame, _ = get_mouse_frame_and_channel(event)
+        frame, _ = get_mouse_frame_and_channel(context, event)
 
         for s in context.sequences:
             if s.frame_final_start >= frame:

--- a/operators/mouse_toggle_mute.py
+++ b/operators/mouse_toggle_mute.py
@@ -38,7 +38,7 @@ class MouseToggleMute(bpy.types.Operator):
 
         # Strip selection
         sequencer.select_all(action='DESELECT')
-        to_select = find_strips_mouse(frame, channel)
+        to_select = find_strips_mouse(context, frame, channel)
 
         if not to_select:
             return {"CANCELLED"}

--- a/operators/preview_closest_cut.py
+++ b/operators/preview_closest_cut.py
@@ -58,8 +58,8 @@ class PreviewClosestCut(bpy.types.Operator):
             return {'CANCELLED'}
 
         if scene.frame_preview_start == start and scene.frame_preview_end == end:
-            start, end = get_frame_range(context.sequences)
-        set_preview_range(start, end)
+            start, end = get_frame_range(context, context.sequences)
+        set_preview_range(context, start, end)
         return {'FINISHED'}
 
     def find_closest_cut_frame(self, context):

--- a/operators/preview_to_selection.py
+++ b/operators/preview_to_selection.py
@@ -34,16 +34,19 @@ class PreviewToSelection(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        scene = bpy.context.scene
-        selection = bpy.context.selected_sequences
+        scene = context.scene
+        selection = context.selected_sequences
         if not selection:
             return {'CANCELLED'}
         frame_start, frame_end = get_frame_range(
-            sequences=bpy.context.selected_sequences, get_from_start=False)
+            context,
+            sequences=context.selected_sequences,
+            get_from_start=False
+        )
 
         if scene.frame_start == frame_start and scene.frame_end == frame_end:
-            frame_start, frame_end = get_frame_range(get_from_start=True)
+            frame_start, frame_end = get_frame_range(context, get_from_start=True)
 
-        set_preview_range(frame_start, frame_end - 1)
+        set_preview_range(context, frame_start, frame_end - 1)
         return {'FINISHED'}
 

--- a/operators/render_for_web.py
+++ b/operators/render_for_web.py
@@ -68,9 +68,9 @@ class RenderForWeb(bpy.types.Operator):
         addon_directory = os.path.dirname(script_file)
 
         # audio
-        if bpy.context.scene.render.ffmpeg.audio_codec == 'NONE':
-            bpy.context.scene.render.ffmpeg.audio_codec = 'AAC'
-            bpy.context.scene.render.ffmpeg.audio_bitrate = 192
+        if context.scene.render.ffmpeg.audio_codec == 'NONE':
+            context.scene.render.ffmpeg.audio_codec = 'AAC'
+            context.scene.render.ffmpeg.audio_bitrate = 192
 
         # video
         if self.preset == 'youtube':
@@ -89,9 +89,9 @@ class RenderForWeb(bpy.types.Operator):
         elif self.name_pattern == 'folder':
             exported_file_name = dirname(path).rsplit(sep="\\", maxsplit=1)[-1]
         elif self.name_pattern == 'scene':
-            exported_file_name = bpy.context.scene.name
+            exported_file_name = context.scene.name
 
-        bpy.context.scene.render.filepath = "//" + exported_file_name + '.mp4'
+        context.scene.render.filepath = "//" + exported_file_name + '.mp4'
 
         if self.auto_render:
             bpy.ops.render.render(

--- a/operators/render_presets/twitter_720p.py
+++ b/operators/render_presets/twitter_720p.py
@@ -29,3 +29,4 @@ bpy.context.scene.render.ffmpeg.minrate = 0
 bpy.context.scene.render.ffmpeg.buffersize = 224 * 8
 bpy.context.scene.render.ffmpeg.packetsize = 2048
 bpy.context.scene.render.ffmpeg.muxrate = 10080000
+

--- a/operators/scene_create_from_selection.py
+++ b/operators/scene_create_from_selection.py
@@ -37,19 +37,19 @@ class SceneCreateFromSelection(bpy.types.Operator):
     def execute(self, context):
         start_scene_name = context.scene.name
 
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         selection_start_frame = min(selection,
                                     key=attrgetter('frame_final_start')).frame_final_start
         selection_start_channel = min(selection, key=attrgetter('channel')).channel
 
         # Create new scene for the scene strip
         bpy.ops.scene.new(type='FULL_COPY')
-        new_scene_name = bpy.context.scene.name
+        new_scene_name = context.scene.name
 
         bpy.ops.sequencer.select_all(action='INVERT')
         bpy.ops.power_sequencer.delete_direct()
         frame_offset = selection_start_frame - 1
-        for s in bpy.context.sequences:
+        for s in context.sequences:
             try:
                 s.frame_start -= frame_offset
             except Exception:
@@ -58,13 +58,13 @@ class SceneCreateFromSelection(bpy.types.Operator):
         bpy.ops.power_sequencer.preview_to_selection()
 
         # Back to start scene
-        bpy.context.screen.scene = bpy.data.scenes[start_scene_name]
+        context.screen.scene = bpy.data.scenes[start_scene_name]
 
         bpy.ops.power_sequencer.delete_direct()
         bpy.ops.sequencer.scene_strip_add(frame_start=selection_start_frame,
                                           channel=selection_start_channel,
                                           scene=new_scene_name)
-        scene_strip = bpy.context.selected_sequences[0]
+        scene_strip = context.selected_sequences[0]
         scene_strip.use_sequence = True
         return {'FINISHED'}
 

--- a/operators/scene_cycle.py
+++ b/operators/scene_cycle.py
@@ -30,11 +30,11 @@ class SceneCycle(bpy.types.Operator):
 
         scene_count = len(scenes)
 
-        if bpy.context.screen.is_animation_playing:
+        if context.screen.is_animation_playing:
             bpy.ops.screen.animation_cancel(restore_frame=False)
         for index in range(scene_count):
-            if bpy.context.scene == scenes[index]:
-                bpy.context.screen.scene = scenes[(index + 1) % scene_count]
+            if context.scene == scenes[index]:
+                context.screen.scene = scenes[(index + 1) % scene_count]
                 break
         return {'FINISHED'}
 

--- a/operators/select_closest_to_mouse.py
+++ b/operators/select_closest_to_mouse.py
@@ -29,12 +29,12 @@ class SelectClosestToMouse(bpy.types.Operator):
         return True
 
     def invoke(self, context, event):
-        self.frame, self.channel = get_mouse_frame_and_channel(event)
+        self.frame, self.channel = get_mouse_frame_and_channel(context, event)
         return self.execute(context)
 
     def execute(self, context):
         try:
-            strip = find_strips_mouse(self.frame, self.channel)[0]
+            strip = find_strips_mouse(context, self.frame, self.channel)[0]
             strip.select = True
         except Exception:
             return {"CANCELLED"}

--- a/operators/select_linked_effect.py
+++ b/operators/select_linked_effect.py
@@ -25,7 +25,7 @@ class SelectLinkedEffect(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        for s in find_linked(bpy.context.selected_sequences):
+        for s in find_linked(context, context.sequences, context.selected_sequences):
             s.select = True
         return {'FINISHED'}
 

--- a/operators/select_related_strips.py
+++ b/operators/select_related_strips.py
@@ -26,7 +26,8 @@ class SelectRelatedStrips(bpy.types.Operator):
 
     find_all = bpy.props.BoolProperty(
         name="Find All",
-        description="Find all related strips recursively so that you can copy the selection without getting an error from Blender",
+        description=("Find all related strips recursively so that you can copy the selection"
+                     " without getting an error from Blender"),
         default=True
     )
 
@@ -43,7 +44,7 @@ class SelectRelatedStrips(bpy.types.Operator):
             related_strips = []
             # Only select direct neighbours and attached effects
             effects = [s for s in context.sequences
-                    if s.type in SequenceTypes.EFFECT]
+                       if s.type in SequenceTypes.EFFECT]
             found_effects = self.find_related_effects(context.selected_sequences, effects)
             related_strips.extend(found_effects)
             while len(found_effects) > 0:
@@ -81,7 +82,7 @@ class SelectRelatedStrips(bpy.types.Operator):
         Returns: A list with all the neighbours of the strip and sometimes
                  neighbours of neighbours and so on.
         """
-        #Respects initial selection
+        # Respects initial selection
         init_selected_strips = [s for s in context.selected_sequences]
 
         neighbours = []
@@ -119,3 +120,4 @@ class SelectRelatedStrips(bpy.types.Operator):
                 except Exception:
                     continue
         return found
+

--- a/operators/set_preview_between_markers.py
+++ b/operators/set_preview_between_markers.py
@@ -25,13 +25,13 @@ class SetPreviewBetweenMarkers(bpy.types.Operator):
         return True
 
     def invoke(self, context, event):
-        if not bpy.context.scene.timeline_markers:
+        if not context.scene.timeline_markers:
             self.report({"ERROR_INVALID_INPUT"},
                         "There are no markers. Operation cancelled.")
             return {"CANCELLED"}
 
-        frame = bpy.context.scene.frame_current
-        previous_marker, next_marker = find_neighboring_markers(frame)
+        frame = context.scene.frame_current
+        previous_marker, next_marker = find_neighboring_markers(context, frame)
 
         if not (previous_marker and next_marker):
             self.report({"ERROR_INVALID_INPUT"},
@@ -44,10 +44,10 @@ class SetPreviewBetweenMarkers(bpy.types.Operator):
         else:
             from operator import attrgetter
             frame_end = max(
-                bpy.context.scene.sequence_editor.sequences,
+                context.scene.sequence_editor.sequences,
                 key=attrgetter('frame_final_end')).frame_final_end
 
         from .utils.sequences import set_preview_range
-        set_preview_range(frame_start, frame_end)
+        set_preview_range(context, frame_start, frame_end)
         return {'FINISHED'}
 

--- a/operators/set_timeline_range.py
+++ b/operators/set_timeline_range.py
@@ -30,7 +30,7 @@ class SetTimelineRange(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        scene = bpy.context.scene
+        scene = context.scene
         if self.adjust == 'start':
             scene.frame_start = scene.frame_current
         elif self.adjust == 'end':

--- a/operators/smart_snap.py
+++ b/operators/smart_snap.py
@@ -34,9 +34,9 @@ class SmartSnap(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        frame_current = bpy.context.scene.frame_current
+        frame_current = context.scene.frame_current
 
-        self.select_strip_handle(bpy.context.selected_sequences, self.side, frame_current)
+        self.select_strip_handle(context.selected_sequences, self.side, frame_current)
         bpy.ops.sequencer.snap(frame=frame_current)
 
         for s in context.selected_sequences:

--- a/operators/snap_selection_to_cursor.py
+++ b/operators/snap_selection_to_cursor.py
@@ -28,9 +28,9 @@ class SnapSelectionToCursor(bpy.types.Operator):
 
     def execute(self, context):
         selection = sorted(
-            bpy.context.selected_sequences,
+            context.selected_sequences,
             key=attrgetter('frame_final_start'))
-        time_move = selection[0].frame_final_start - bpy.context.scene.frame_current
+        time_move = selection[0].frame_final_start - context.scene.frame_current
 
         bpy.ops.power_sequencer.select_related_strips()
         bpy.ops.transform.seq_slide(value=(-time_move, 0))

--- a/operators/swap_strips.py
+++ b/operators/swap_strips.py
@@ -35,12 +35,12 @@ class SwapStrips(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return len(bpy.context.selected_sequences) in range(1, 3)
+        return len(context.selected_sequences) in range(1, 3)
 
     def execute(self, context):
         strip_1 = context.selected_sequences[0]
         if len(context.selected_sequences) == 1:
-            strip_2 = self.find_closest_strip_vertical(strip_1, self.direction)
+            strip_2 = self.find_closest_strip_vertical(context, strip_1, self.direction)
         else:
             strip_2 = context.selected_sequences[1]
         if not strip_2 or strip_1.lock or strip_2.lock:
@@ -174,7 +174,7 @@ class SwapStrips(bpy.types.Operator):
                     u.channel += 1
             s.channel = channel
 
-    def find_closest_strip_vertical(self, strip, direction):
+    def find_closest_strip_vertical(self, context, strip, direction):
         """
         Finds the closest strip to a given strip in a specific direction.
         Args:
@@ -182,7 +182,7 @@ class SwapStrips(bpy.types.Operator):
         Returns: The closest strip to the given strip, in the proper direction.
                  If no strip is found, returns None.
         """
-        strips_in_range = (s for s in bpy.context.sequences
+        strips_in_range = (s for s in context.sequences
                            if strip.frame_final_start <= s.frame_final_start
                            and s.frame_final_end <= strip.frame_final_end)
         if direction == "up":

--- a/operators/synchronize_titles.py
+++ b/operators/synchronize_titles.py
@@ -31,8 +31,8 @@ class SynchronizeTitles(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        markers = bpy.context.scene.timeline_markers
-        selection = bpy.context.selected_sequences
+        markers = context.scene.timeline_markers
+        selection = context.selected_sequences
 
         if not markers and selection:
             if not markers:
@@ -42,7 +42,7 @@ class SynchronizeTitles(bpy.types.Operator):
                             "No sequences selected, operation cancelled.")
             return {"CANCELLED"}
 
-        title_markers = self.find_markers(self.TITLE_REGEX)
+        title_markers = self.find_markers(context, self.TITLE_REGEX)
         if not title_markers:
             self.report({"INFO"},
                         "No title markers found, operation cancelled.")
@@ -81,7 +81,7 @@ class SynchronizeTitles(bpy.types.Operator):
                     break
         return return_list
 
-    def find_markers(self, regex):
+    def find_markers(self, context, regex):
         """Finds and returns all markers using REGEX
         Args:
             - regex, the re match pattern to use"""
@@ -90,7 +90,7 @@ class SynchronizeTitles(bpy.types.Operator):
 
         import re
         regex = re.compile(regex)
-        markers = bpy.context.scene.timeline_markers
+        markers = context.scene.timeline_markers
         markers = (m for m in markers if regex.match(m.name))
         return markers
 

--- a/operators/toggle_selected_mute.py
+++ b/operators/toggle_selected_mute.py
@@ -36,12 +36,10 @@ class ToggleSelectedMute(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
 
         if self.use_unselected:
-            selection = [
-                s for s in bpy.context.sequences if s not in selection
-            ]
+            selection = [s for s in context.sequences if s not in selection]
 
         if not selection:
             self.report({"WARNING"}, "No sequences to toggle muted")

--- a/operators/toggle_waveforms.py
+++ b/operators/toggle_waveforms.py
@@ -39,9 +39,9 @@ class ToggleWaveforms(bpy.types.Operator):
         return True
 
     def execute(self, context):
-        selection = bpy.context.selected_sequences
+        selection = context.selected_sequences
         if not selection:
-            selection = bpy.context.sequences
+            selection = context.sequences
 
         sequences = [s for s in selection if s.type in SequenceTypes.SOUND]
 

--- a/operators/trim_three_point_edit.py
+++ b/operators/trim_three_point_edit.py
@@ -37,16 +37,16 @@ class TrimThreePointEdit(bpy.types.Operator):
         return context.sequences
 
     def invoke(self, context, event):
-        frame, channel = get_mouse_frame_and_channel(event)
+        frame, channel = get_mouse_frame_and_channel(context, event)
         bpy.ops.sequencer.select_all(action='DESELECT')
         bpy.ops.power_sequencer.select_closest_to_mouse(
             frame=frame, channel=channel)
-        if not bpy.context.selected_sequences:
+        if not context.selected_sequences:
             bpy.ops.power_sequencer.select_strips_under_cursor()
         return self.execute(context)
 
     def execute(self, context):
-        if not bpy.context.selected_sequences:
+        if not context.selected_sequences:
             return {'CANCELLED'}
         bpy.ops.power_sequencer.smart_snap(side=self.side)
         return {'FINISHED'}

--- a/operators/utils/calculate_distance.py
+++ b/operators/utils/calculate_distance.py
@@ -3,3 +3,4 @@ from math import sqrt
 
 def calculate_distance(x1, y1, x2, y2):
     return sqrt((x2 - x1)**2 + (y2 - y1)**2)
+

--- a/operators/utils/convert_duration_to_frames.py
+++ b/operators/utils/convert_duration_to_frames.py
@@ -1,4 +1,3 @@
-import bpy
+def convert_duration_to_frames(context, duration):
+    return round(duration * context.scene.render.fps / context.scene.render.fps_base)
 
-def convert_duration_to_frames(duration):
-    return round(duration * bpy.context.scene.render.fps / bpy.context.scene.render.fps_base)

--- a/operators/utils/draw.py
+++ b/operators/utils/draw.py
@@ -19,9 +19,9 @@ def draw_arrow_head(center, size, points_right=True):
     """
     direction = 1 if points_right else -1
 
-    point_upper = Vector([ center.x - size.x/2 * direction, center.y + size.y/2 ])
-    point_tip = Vector([ center.x + size.x/2 * direction, center.y ])
-    point_lower = Vector([ center.x - size.x/2 * direction, center.y - size.y/2 ])
+    point_upper = Vector([center.x - size.x/2 * direction, center.y + size.y/2])
+    point_tip = Vector([center.x + size.x/2 * direction, center.y])
+    point_lower = Vector([center.x - size.x/2 * direction, center.y - size.y/2])
 
     draw_line(point_upper, point_tip)
     draw_line(point_tip, point_lower)
@@ -50,3 +50,4 @@ def draw_arrow_head(center, size, points_right=True):
 #     bgl.glVertex2f(start_x, start_y)
 #     bgl.glVertex2f(end_x, end_y)
 #     bgl.glEnd()
+

--- a/operators/utils/find_gaps.py
+++ b/operators/utils/find_gaps.py
@@ -1,10 +1,10 @@
 # sort bpy.context.sequences by frame_final_start, frame_final_end
 # loop over and find the first or all gaps in the frame range
 # subtract the gap's size from the frame_start of all strips after the gap(s), reusing the sorted sequences list
-
-import bpy
 from operator import attrgetter
 
-def find_gaps(sequences):
+
+def find_gaps(context, sequences):
     sorted_sequences = sorted(sequences, key=attrgetter('frame_final_start', 'frame_final_end'))
     # Detect disconnected sequence blocks, starting from first frame in the sequencer
+

--- a/operators/utils/find_linked_sequences.py
+++ b/operators/utils/find_linked_sequences.py
@@ -1,10 +1,9 @@
-import bpy
 from .get_frame_range import get_frame_range
 from .global_settings import SequenceTypes
 from .is_in_range import is_in_range
 
 
-def find_linked(sequences):
+def find_linked(context, sequences, selected_sequences):
     """
     Takes a list of sequences and returns a list of all the sequences
     and effects that are linked in time
@@ -14,8 +13,8 @@ def find_linked(sequences):
 
     Returns a list of all the linked sequences, but not the sequences passed to the function
     """
-    start, end = get_frame_range(sequences)
-    sequences_in_range = [s for s in bpy.context.sequences if is_in_range(s, start, end)]
+    start, end = get_frame_range(context, sequences, selected_sequences)
+    sequences_in_range = [s for s in sequences if is_in_range(context, s, start, end)]
     effects = (s for s in sequences_in_range if s.type in SequenceTypes.EFFECT)
     selected_effects = (s for s in sequences if s.type in SequenceTypes.EFFECT)
 
@@ -45,3 +44,4 @@ def find_linked(sequences):
                 linked_sequences.append(e.input_2)
 
     return linked_sequences
+

--- a/operators/utils/find_neighboring_markers.py
+++ b/operators/utils/find_neighboring_markers.py
@@ -1,9 +1,6 @@
-import bpy
-
-
-def find_neighboring_markers(frame=None):
+def find_neighboring_markers(context, frame=None):
     """Returns a tuple containing the closest marker to the left and to the right of the frame"""
-    markers = bpy.context.scene.timeline_markers
+    markers = context.scene.timeline_markers
 
     if not (frame and markers):
         return None, None
@@ -19,3 +16,4 @@ def find_neighboring_markers(frame=None):
             break
 
     return previous_marker, next_marker
+

--- a/operators/utils/find_sequences_after.py
+++ b/operators/utils/find_sequences_after.py
@@ -1,6 +1,4 @@
-import bpy
-
-def find_sequences_after(sequence):
+def find_sequences_after(context, sequence):
     """
     Finds the strips following the sequences passed to the function
     Args:
@@ -8,5 +6,6 @@ def find_sequences_after(sequence):
     Returns all the strips after the sequence in the current context
     """
     sequence_start = sequence.frame_final_start
-    return [s for s in bpy.context.sequences
+    return [s for s in context.sequences
             if s.frame_final_start > sequence_start]
+

--- a/operators/utils/find_snap_candidate.py
+++ b/operators/utils/find_snap_candidate.py
@@ -1,11 +1,9 @@
-import bpy
-
-def find_snap_candidate(frame=0):
+def find_snap_candidate(context, frame=0):
     """
     Finds and returns the best frame snap candidate around the frame
     """
     closest_cut_frame = 1000000
-    for s in bpy.context.sequences:
+    for s in context.sequences:
         start_to_frame = frame - s.frame_final_start
         end_to_frame = frame - s.frame_final_end
         distance_to_start = abs(start_to_frame)
@@ -20,3 +18,4 @@ def find_snap_candidate(frame=0):
         if abs(frame - snap_candidate) < abs(frame - closest_cut_frame):
             closest_cut_frame = snap_candidate
     return closest_cut_frame
+

--- a/operators/utils/find_strips_mouse.py
+++ b/operators/utils/find_strips_mouse.py
@@ -1,7 +1,4 @@
-import bpy
-
-
-def find_strips_mouse(frame, channel, select_linked=False):
+def find_strips_mouse(context, frame, channel, select_linked=False):
     """
     Finds a list of sequences to select based on the mouse position
     or using the time cursor.
@@ -14,9 +11,10 @@ def find_strips_mouse(frame, channel, select_linked=False):
     Returns the sequence(s) under the mouse cursor as a list
     Returns an empty list if nothing found
     """
-    sequences = [s for s in bpy.context.sequences if not s.lock and s.channel == channel]
+    sequences = [s for s in context.sequences if not s.lock and s.channel == channel]
     try:
-        under_mouse = [next(s for s in sequences if s.frame_final_start <= frame <= s.frame_final_end)]
+        under_mouse = [next(s for s in sequences
+                            if s.frame_final_start <= frame <= s.frame_final_end)]
     except StopIteration:
         return []
 
@@ -27,3 +25,4 @@ def find_strips_mouse(frame, channel, select_linked=False):
         return under_mouse.append(linked_strips)
     else:
         return under_mouse
+

--- a/operators/utils/get_frame_range.py
+++ b/operators/utils/get_frame_range.py
@@ -1,8 +1,7 @@
-import bpy
 from operator import attrgetter
 
 
-def get_frame_range(sequences, get_from_start=False):
+def get_frame_range(context, sequences, get_from_start=False):
     """
     Returns a tuple with the minimum and maximum frames of the
     list of passed sequences.
@@ -13,9 +12,10 @@ def get_frame_range(sequences, get_from_start=False):
         this boolean is True
     """
     if not sequences:
-        scene = bpy.context.scene
+        scene = context.scene
         return scene.frame_start, scene.frame_end
 
     start = 1 if get_from_start else min(sequences, key=attrgetter('frame_final_start')).frame_final_start
     end = max(sequences, key=attrgetter('frame_final_end')).frame_final_end
     return start, end
+

--- a/operators/utils/get_mouse_view_coords.py
+++ b/operators/utils/get_mouse_view_coords.py
@@ -1,14 +1,15 @@
-import bpy
 from math import floor
 
-def get_mouse_frame_and_channel(event):
+
+def get_mouse_frame_and_channel(context, event):
     """
     Convert mouse coordinates from the event, from
     pixels to frame, channel.
     Returns a tuple of frame, channel as integers
     """
-    view2d = bpy.context.region.view2d
+    view2d = context.region.view2d
     frame, channel = view2d.region_to_view(
         event.mouse_region_x,
         event.mouse_region_y)
     return round(frame), floor(channel)
+

--- a/operators/utils/global_settings.py
+++ b/operators/utils/global_settings.py
@@ -1,7 +1,3 @@
-from enum import Enum
-import bpy
-
-
 class ProjectSettings():
     RESOLUTION_X = 1920
     RESOLUTION_Y = 1080
@@ -36,7 +32,9 @@ class Extensions():
     """
     Tuples of file types for checks when importing files
     Attributes:
-        DICT: A dictionary of file types. Each key (IMG, AUDIO, VIDEO, PSD) contains a set of strings that represent a file name with a wildcard and extension ("*.ext"). To use with the glob builtin module.
+        DICT: A dictionary of file types. Each key (IMG, AUDIO, VIDEO, PSD) contains a set
+        of strings that represent a file name with a wildcard and extension ("*.ext"). To
+        use with the glob builtin module.
     """
     DICT = {
         "IMG": ("*.png", "*.jpg", "*.jpeg"),

--- a/operators/utils/is_ffmpeg_available.py
+++ b/operators/utils/is_ffmpeg_available.py
@@ -18,3 +18,4 @@ def is_ffmpeg_available():
 
     except OSError:
         return False
+

--- a/operators/utils/is_in_range.py
+++ b/operators/utils/is_in_range.py
@@ -1,4 +1,4 @@
-def is_in_range(sequence, start, end):
+def is_in_range(context, sequence, start, end):
     """
     Checks if a single sequence's start or end is in the range
 
@@ -10,3 +10,4 @@ def is_in_range(sequence, start, end):
     s_start = sequence.frame_final_start
     s_end = sequence.frame_final_end
     return start <= s_start <= end or start <= s_end <= end
+

--- a/operators/utils/set_preview_range.py
+++ b/operators/utils/set_preview_range.py
@@ -1,14 +1,12 @@
-import bpy
-
-
-def set_preview_range(start, end):
+def set_preview_range(context, start, end):
     """Sets the preview range and timeline render range"""
     if not (start and end) and start != 0:
         raise AttributeError('Missing start or end parameter')
 
-    scene = bpy.context.scene
+    scene = context.scene
 
     scene.frame_start = start
     scene.frame_end = end
     scene.frame_preview_start = start
     scene.frame_preview_end = end
+

--- a/operators/utils/slice_contiguous_sequence_list.py
+++ b/operators/utils/slice_contiguous_sequence_list.py
@@ -1,6 +1,7 @@
 from operator import attrgetter
 
-def slice_selection(sequences):
+
+def slice_selection(context, sequences):
     """
     Takes a list of sequences and breaks it down
     into multiple lists of connected sequences
@@ -39,3 +40,4 @@ def slice_selection(sequences):
             broken_selection.append(temp_list)
         index += 1
     return broken_selection
+

--- a/operators/utils/trim_strips.py
+++ b/operators/utils/trim_strips.py
@@ -4,7 +4,8 @@ Trims strips in the timeline between the start and end frame. The caller must pa
 import bpy
 
 
-def trim_strips(start_frame, end_frame, select_mode,
+def trim_strips(context,
+                start_frame, end_frame, select_mode,
                 strips_to_trim=[], strips_to_delete=[]):
     trim_start = min(start_frame, end_frame)
     trim_end = max(start_frame, end_frame)
@@ -16,7 +17,7 @@ def trim_strips(start_frame, end_frame, select_mode,
             s.select = True
             bpy.ops.sequencer.cut(frame=trim_start, type='SOFT', side='RIGHT')
             bpy.ops.sequencer.cut(frame=trim_end, type='SOFT', side='LEFT')
-            strips_to_delete.append(bpy.context.selected_sequences[0])
+            strips_to_delete.append(context.selected_sequences[0])
             continue
         elif s.frame_final_start < trim_end and s.frame_final_end > trim_end:
             s.frame_final_start = trim_end
@@ -29,3 +30,4 @@ def trim_strips(start_frame, end_frame, select_mode,
             s.select = True
         bpy.ops.sequencer.delete()
     return {'FINISHED'}
+

--- a/ui/menu_contextual.py
+++ b/ui/menu_contextual.py
@@ -15,15 +15,15 @@ class PowerSequencerMenuContextual(bpy.types.Menu):
                 'wm.save_as_mainfile', icon='SAVE_AS', text='Save as')
             return
 
-        if not bpy.context.sequences:
+        if not context.sequences:
             layout.operator(
                 'power_sequencer.import_local_footage',
                 icon='SEQUENCE',
                 text='Import local footage')
             return
 
-        selection = bpy.context.selected_sequences
-        active_strip = bpy.context.scene.sequence_editor.active_strip
+        selection = context.selected_sequences
+        active_strip = context.scene.sequence_editor.active_strip
         types = set([s.type for s in selection])
 
         if active_strip.type == 'GAMMA_CROSS':
@@ -76,3 +76,4 @@ class PowerSequencerMenuContextual(bpy.types.Menu):
             'power_sequencer.render_video',
             icon='RENDER_ANIMATION',
             text='Render video for the web')
+


### PR DESCRIPTION
Needs some testing to be sure all operators are working properly after
`bpy.context` -> `context` substitution