### PR TITLE
Add Open Scene from Strip operator

### DIFF
--- a/operators/open_scene_from_strip.py
+++ b/operators/open_scene_from_strip.py
@@ -10,7 +10,9 @@ class OpenSceneStrip(bpy.types.Operator):
         'name': doc_name(__qualname__),
         'demo': '',
         'description': doc_description(__doc__),
-        'shortcuts': [],
+        'shortcuts': [
+        ({'type': 'E', 'value': 'PRESS', 'alt': True, 'ctrl': True}, {}, 'Open Strip Scene')
+        ],
         'keymap': 'Sequencer'
     }
 

--- a/operators/open_scene_from_strip.py
+++ b/operators/open_scene_from_strip.py
@@ -1,0 +1,30 @@
+import bpy
+
+from .utils.doc import doc_name, doc_idname, doc_brief, doc_description
+
+class OpenSceneStrip(bpy.types.Operator):
+    """
+    Sets the current scene to the scene in the SceneStrip
+    """
+    doc = {
+        'name': doc_name(__qualname__),
+        'demo': '',
+        'description': doc_description(__doc__),
+        'shortcuts': [],
+        'keymap': 'Sequencer'
+    }
+
+    bl_idname = doc_idname(doc['name'])
+    bl_label = doc['name']
+    bl_description = doc_brief(doc['description'])
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.sequence_editor.active_strip.type == 'SCENE'
+
+    def execute(self, context):
+        strip_scene = context.scene.sequence_editor.active_strip.scene
+        context.screen.scene = bpy.data.scenes[strip_scene.name]
+
+        return {'FINISHED'}


### PR DESCRIPTION
Hey there, this one I thought about doing since I was working with SceneStrip workflows.

This is just a to switch the current scene to the one used in the active SceneStrip. By setting a shortcut, in my case <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>E</kbd>, it creates a really cool workflow bouncing from a strip to another, fixing animations, going back, etc... :)

Wachu you think?