### PR TITLE
Add Popup to set Still Image length

### DIFF
--- a/operators/make_still_image.py
+++ b/operators/make_still_image.py
@@ -2,6 +2,7 @@ import bpy
 import operator
 
 from .utils.global_settings import SequenceTypes
+from .utils.convert_duration_to_frames import convert_duration_to_frames
 from .utils.doc import doc_name, doc_idname, doc_brief, doc_description
 
 class MakeStillImage(bpy.types.Operator):
@@ -24,11 +25,11 @@ class MakeStillImage(bpy.types.Operator):
     bl_description = doc_brief(doc['description'])
     bl_options = {'REGISTER', 'UNDO'}
 
-    strip_duration = bpy.props.IntProperty(
-        name="Strip length",
-        description="Length of the new strip in frames, if 0 it will use the gap as its length",
-        default=0,
-        min = 0)
+    strip_duration = bpy.props.FloatProperty(
+        name="Strip Duration",
+        description="The duration in seconds of the new strip, if 0.0 it will use the gap as its duration",
+        default=0.0,
+        min = 0.0)
 
     @classmethod
     def poll(cls, context):
@@ -45,7 +46,7 @@ class MakeStillImage(bpy.types.Operator):
         transform = bpy.ops.transform
 
         start_frame = scene.frame_current
-        offset = self.strip_duration
+        offset = convert_duration_to_frames(context, self.strip_duration)
 
         if active.type not in SequenceTypes.VIDEO:
             self.report({"ERROR_INVALID_INPUT"},
@@ -63,7 +64,7 @@ class MakeStillImage(bpy.types.Operator):
         if start_frame == active.frame_final_start:
             scene.frame_current = start_frame + 1
 
-        if self.strip_duration < 1:
+        if self.strip_duration <= 0.0:
             strips = sorted(scene.sequence_editor.sequences,
                             key=operator.attrgetter('frame_final_start'))
 
@@ -72,7 +73,6 @@ class MakeStillImage(bpy.types.Operator):
                    and s.channel == active.channel:
                     next = s
                     break
-
             offset = next.frame_final_start - active.frame_final_end
 
         active.select = True


### PR DESCRIPTION
Now it always shows a Popup Menu, which increases the discoverability of the feature, since the current implementation relies on the users pressing <kbd>F6</kbd> to set the strip's length.

I also removed the bool property and instead I'm using the length the user sets to define if it shall use the gap or a user-defined length. 

What about that, sounds good doesn't it? 😄 