### PR TITLE
add subtyper DIR_PATH to video export path property

### DIFF
--- a/addon_preferences.py
+++ b/addon_preferences.py
@@ -9,6 +9,7 @@ from . import addon_updater_ops
 class ProxyPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
     video_export_path = StringProperty(
+        subtype="DIR_PATH",
         name="Video render folder",
         description="Relative folder to save videos rendered with the add-on",
         default="")


### PR DESCRIPTION
Here's the clean branch for this commit !
Added DIR_PATH to the video export path property in the user prefs.
It allows to automatically draw in users prefs of the addon the UI button to browse for a path directory