### PR TITLE
Fix jump_to_cut poll

### DIFF
--- a/operators/jump_to_cut.py
+++ b/operators/jump_to_cut.py
@@ -39,7 +39,7 @@ class JumpToCut(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return len(context.sequences) > 0
+        return context.sequences is not None and len(context.sequences) > 0
 
     def execute(self, context):
         jump_to_frame = None


### PR DESCRIPTION
It's an easy fix, just check for `None` in `poll` - it should be done on all operators, but some have more complex `poll` functions, we'll catch them as errors get found. closes #305 