### PR TITLE
Close #355: Mouse cut tool redesign for Blender 2.80

### DIFF
--- a/operators/mouse_cut.py
+++ b/operators/mouse_cut.py
@@ -81,6 +81,8 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
 
     draw_handler = None
 
+    use_audio_scrub = False
+
     event_shift_released = True
     event_alt_released = True
 
@@ -92,6 +94,9 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
         if context.screen.is_animation_playing:
             bpy.ops.screen.animation_cancel(restore_frame=False)
 
+        self.use_audio_scrub = context.scene.use_audio_scrub
+        context.scene.use_audio_scrub = False
+
         self.update_time_cursor(context, event)
         self.trim_initialize(event)
         self.draw_start(context, event)
@@ -100,7 +105,10 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
         return {'RUNNING_MODAL'}
 
     def modal(self, context, event):
+
         if event.type in {'ESC'}:
+            self.draw_stop()
+            context.scene.use_audio_scrub = self.use_audio_scrub
             return {'CANCELLED'}
 
         # # Toggle cursor select mode
@@ -123,6 +131,7 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
         if event.type == 'LEFTMOUSE':
             self.trim_apply(context, event)
             self.draw_stop()
+            context.scene.use_audio_scrub = self.use_audio_scrub
             return {'FINISHED'}
 
         if event.type == 'MOUSEMOVE':

--- a/operators/mouse_cut.py
+++ b/operators/mouse_cut.py
@@ -18,9 +18,9 @@ if not bpy.app.background:
 
 class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
     """
-    *brief* Fast strip cutting based on mouse position
+    *brief* Cut or Trim strips quickly with the mouse cursor
 
-
+    Click somehwere in the Sequencer to insert a cut, click and drag to trim
     With this function you can quickly cut and remove a section of strips while keeping or
     collapsing the remaining gap.
 
@@ -31,12 +31,22 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
         'demo': 'https://i.imgur.com/wVvX4ex.gif',
         'description': doc_description(__doc__),
         'shortcuts': [
-            ({'type': 'LEFTMOUSE', 'value': 'PRESS', 'ctrl': True},
-             {'gap_remove': False},
-             'Cut on mousemove, keep gap'),
-            ({'type': 'LEFTMOUSE', 'value': 'PRESS', 'ctrl': True, 'shift': True},
-             {'gap_remove': True},
-             'Cut on mousemove, remove gap'),
+            ({'type': 'T', 'value': 'PRESS'},
+             {'select_mode': 'contextual'},
+             {'remove_gaps': False},
+             'Trim using the mouse cursor'),
+            ({'type': 'T', 'value': 'PRESS', 'alt': True},
+             {'select_mode': 'contextual'},
+             {'remove_gaps': True},
+             'Trim using the mouse cursor and remove gaps'),
+            ({'type': 'T', 'value': 'PRESS', 'shift': True},
+             {'select_mode': 'cursor'},
+             {'remove_gaps': False},
+             'Trim in all channels'),
+            ({'type': 'T', 'value': 'PRESS', 'shift': True, 'alt': True},
+             {'select_mode': 'cursor'},
+             {'remove_gaps': True},
+             'Trim in all channels and remove gaps'),
         ],
         'keymap': 'Sequencer'
     }
@@ -46,170 +56,183 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     select_mode: bpy.props.EnumProperty(
-        items=[('mouse', 'Mouse',
-                'Only select the strip hovered by the mouse'),
-               ('cursor', 'Time cursor',
+        items=[('cursor', 'Time cursor',
                 'Select all of the strips the time cursor overlaps'),
-               ('smart', 'Smart',
+               ('contextual', 'Smart',
                 'Uses the selection if possible, else uses the other modes')],
         name="Selection mode",
         description="Cut only the strip under the mouse or all strips under the time cursor",
-        default='smart')
+        default='contextual')
     select_linked: bpy.props.BoolProperty(
         name="Use linked time",
-        description="In mouse or smart mode, always cut linked strips if this is checked",
+        description="In mouse or contextual mode, always cut linked strips if this is checked",
         default=False)
     gap_remove: bpy.props.BoolProperty(
         name="Remove gaps",
         description="When trimming the sequences, remove gaps automatically",
         default=True)
-    cut_gaps: bpy.props.BoolProperty(
-        name="Cut gaps",
-        description="If you click on a gap, remove it",
-        default=True)
 
-    auto_move_cursor: bpy.props.BoolProperty(
-        name="Auto move cursor",
-        description="When trimming the sequence, auto move the cursor if playback is active",
-        default=True)
-    cursor_offset: bpy.props.IntProperty(
-        name="Cursor trim offset",
-        description="On trim, during playback, offset the cursor to better see if the cut works",
-        default=12,
-        min=0)
-    threshold_trim_distance: bpy.props.IntProperty(
-        name="Tablet trim distance",
-        description="If you use a pen tablet, the trim will only happen past this distance",
-        default=6,
-        min=0)
+    TABLET_TRIM_DISTANCE_THRESHOLD = 6
+    trim_start, channel_start = 0, 0
+    trim_end, end_channel = 0, 0
+    is_trimming = False
 
-    use_pen_tablet = False
-    mouse_start_x, mouse_start_y = 0.0, 0.0
+    mouse_start_y = -1.0
 
-    frame_start, channel_start = 0, 0
-    frame_end, end_channel = 0, 0
-    cut_mode = ''
-    initially_clicked_strips = None
+    draw_handler = None
 
-    mouse_vec_start = Vector([0, 0])
-    handle_cut_trim_line = None
-
-    target_strips = []
+    event_shift_released = True
+    event_alt_released = True
 
     @classmethod
     def poll(cls, context):
         return context.sequences is not None
 
     def invoke(self, context, event):
-        # Detect pen tablets
-        if event.pressure not in [0.0, 1.0]:
-            self.use_pen_tablet = True
-            self.mouse_start_x, self.mouse_start_y = event.mouse_region_x, event.mouse_region_y
+        if context.screen.is_animation_playing:
+            bpy.ops.screen.animation_cancel(restore_frame=False)
 
-        frame_float, channel_float = context.region.view2d.region_to_view(
-            x=event.mouse_region_x, y=event.mouse_region_y)
-        self.frame_start, self.channel_start = round(frame_float), floor(channel_float)
-        self.frame_end = self.frame_start
+        self.update_time_cursor(context, event)
+        self.trim_initialize(event)
+        self.draw_start(context, event)
 
-        context.scene.frame_current = self.frame_start
-
-        # Drawing
-        self.mouse_vec_start = Vector([event.mouse_region_x, event.mouse_region_y])
-        self.initially_clicked_strips = find_strips_mouse(
-            context, self.frame_start, self.channel_start, select_linked=self.select_linked
-        )
         context.window_manager.modal_handler_add(self)
         return {'RUNNING_MODAL'}
 
     def modal(self, context, event):
         if event.type in {'ESC'}:
             return {'CANCELLED'}
-        # On mouse release, confirming the action
-        if event.type == 'LEFTMOUSE' and event.value == 'RELEASE':
-            if self.handle_cut_trim_line:
-                bpy.types.SpaceSequenceEditor.draw_handler_remove(
-                    self.handle_cut_trim_line, 'WINDOW')
 
-            self.select_mode = 'cursor' if event.shift else 'smart'
+        # # Toggle cursor select mode
+        # if event.type in ['LEFT_SHIFT', 'RIGHT_SHIFT']:
+        #     if event.value == 'PRESS' and self.event_shift_released:
+        #         self.event_shift_released = False
+        #         self.select_mode = 'contextual' if self.select_mode == 'cursor' else 'cursor'
+        #     elif event.value == 'RELEASE' and not self.event_shift_released:
+        #         self.event_shift_released = True
 
-            cursor_distance = abs(event.mouse_region_x - self.mouse_start_x)
-            # Cut
-            if (self.use_pen_tablet and cursor_distance <= self.threshold_trim_distance) \
-               or self.frame_start == self.frame_end:
-                to_select = self.find_strips_to_cut(context)
-                bpy.ops.sequencer.select_all(action='DESELECT')
-                for s in to_select:
-                    s.select = True
-                self.cut_strips_or_gap(context, self.frame_start)
-            # Trim
-            else:
-                to_select, to_delete = self.find_strips_to_trim(context)
-                trim_strips(context,
-                            self.frame_start, self.frame_end, self.select_mode,
-                            to_select, to_delete)
+        # # Toggle remove gaps
+        # if event.type in ['LEFT_ALT', 'RIGHT_SHIFT']:
+        #     if event.value == 'PRESS' and self.event_alt_released:
+        #         self.event_alt_released = False
+        #         self.remove_gaps = not self.remove_gaps
+        #     elif event.value == 'RELEASE' and not self.event_alt_released:
+        #         self.event_alt_released = True
 
-                if self.gap_remove and self.select_mode == 'cursor':
-                    context.scene.frame_current = min(self.frame_start, self.frame_end)
-                    bpy.ops.power_sequencer.gap_remove()
-                else:
-                    context.scene.frame_current = self.frame_end
+        # Start and end trim
+        if event.type == 'LEFTMOUSE':
+            self.trim_apply(context, event)
+            self.draw_stop()
             return {'FINISHED'}
-        elif event.type == 'MOUSEMOVE':
-            if self.handle_cut_trim_line:
-                bpy.types.SpaceSequenceEditor.draw_handler_remove(
-                    self.handle_cut_trim_line, 'WINDOW'
-                )
 
-            to_select, to_delete = self.find_strips_to_trim(context)
-            self.target_strips = to_select
-            self.target_strips.extend(to_delete)
+        if event.type == 'MOUSEMOVE':
+            if self.mouse_start_y < 0.0:
+                self.mouse_start_y = event.mouse_region_y
 
-            # If trimming a single strip, limit the drawing range
-            if self.initially_clicked_strips and not event.shift:
-                s = self.initially_clicked_strips[0]
-                s_frame_start, s_frame_end = s.frame_final_start, s.frame_final_end
-                s_x_start = context.region.view2d.view_to_region(s_frame_start, 1)[0]
-                s_x_end = context.region.view2d.view_to_region(s_frame_end, 1)[0]
-
-                draw_end_x = max(s_x_start, min(event.mouse_region_x, s_x_end))
-            else:
-                draw_end_x = event.mouse_region_x
-
-            # Drawing
-            args = (self, context,
-                    Vector([self.mouse_vec_start.x, self.mouse_vec_start.y]),
-                    Vector([round(draw_end_x), self.mouse_vec_start.y]),
-                    event.shift)
-            self.handle_cut_trim_line = bpy.types.SpaceSequenceEditor.draw_handler_add(
-                draw_cut_trim, args, 'WINDOW', 'POST_PIXEL')
-
-            # Update the time cursor's position based on the mouse position
-            x, y = context.region.view2d.region_to_view(
-                x=event.mouse_region_x, y=event.mouse_region_y)
-            self.frame_end, self.end_channel = round(x), floor(y)
-            context.scene.frame_current = self.frame_end
+            self.draw_stop()
+            self.update_time_cursor(context, event)
+            self.trim_end = context.scene.frame_current
+            self.draw_start(context, event)
             return {'PASS_THROUGH'}
+
+        if event.type in ['RET', 'T'] and event.value == 'PRESS':
+            self.draw_stop()
+            return {'FINISHED'}
+
         return {'RUNNING_MODAL'}
+
+    def trim_initialize(self, event):
+        self.trim_start, self.channel_start = get_frame_and_channel(event)
+        self.trim_end = self.trim_start
+        self.is_trimming = True
+
+    def trim_apply(self, context, event):
+        start_x = context.region.view2d.region_to_view(x=event.mouse_region_x, y=event.mouse_region_y)[0]
+        distance_to_start = abs(event.mouse_region_x - start_x)
+
+        is_cutting = self.trim_start == self.trim_end or \
+            event.is_tablet and distance_to_start <= self.TABLET_TRIM_DISTANCE_THRESHOLD
+        if is_cutting:
+            self.cut(context)
+        else:
+            self.trim(context)
+        self.is_trimming = False
+
+    def update_time_cursor(self, context, event):
+        self.trim_end = get_frame_and_channel(event)[0]
+        context.scene.frame_current = self.trim_end
+
+    def draw_start(self, context, event):
+        to_select, to_delete = self.find_strips_to_trim(context)
+        target_strips = to_select + to_delete
+
+        # # Limit drawing range if trimming a single strip
+        # under_mouse = find_strips_mouse(context, self.trim_start, self.channel_start, select_linked=self.select_linked)
+        # if self.select_mode == 'contextual' and under_mouse:
+        #     s = under_mouse[0]
+        #     strip_start_x = context.region.view2d.view_to_region(s.frame_final_start, 1)[0]
+        #     strip_end_x = context.region.view2d.view_to_region(s.frame_final_end, 1)[0]
+        #     draw_end_x = max(strip_start_x, min(event.mouse_region_x, strip_end_x))
+        # else:
+        #     draw_end_x = event.mouse_region_x
+
+        draw_args = (self, context,
+                     self.trim_start,
+                     self.trim_end,
+                     self.mouse_start_y,
+                     target_strips,
+                     self.remove_gaps)
+        self.draw_handler = bpy.types.SpaceSequenceEditor.draw_handler_add(
+            draw, draw_args, 'WINDOW', 'POST_PIXEL')
+
+    def draw_stop(self):
+        if self.draw_handler:
+            bpy.types.SpaceSequenceEditor.draw_handler_remove(self.draw_handler, 'WINDOW')
+
+    def cut(self, context):
+        to_select = self.find_strips_to_cut(context)
+        bpy.ops.sequencer.select_all(action='DESELECT')
+        for s in to_select:
+            s.select = True
+
+        frame_current = context.scene.frame_current
+        context.scene.frame_current = self.trim_start
+        bpy.ops.sequencer.cut(
+            frame=context.scene.frame_current,
+            type='SOFT',
+            side='BOTH')
+        context.scene.frame_current = frame_current
+
+    def trim(self, context):
+        to_select, to_delete = self.find_strips_to_trim(context)
+        trim_strips(context,
+                    self.trim_start, self.trim_end, self.select_mode,
+                    to_select, to_delete)
+        if self.remove_gaps and self.select_mode == 'cursor':
+            context.scene.frame_current = min(self.trim_start, self.trim_end)
+            bpy.ops.power_sequencer.remove_gaps()
+        else:
+            context.scene.frame_current = self.trim_end
 
     def find_strips_to_cut(self, context):
         """
-        Finds and Returns a list of strips to cut
+        Returns a list of strips to cut
         """
-        to_select = []
+        to_cut = []
         overlapping_strips = []
-        if self.select_mode == 'smart':
+        if self.select_mode == 'contextual':
             overlapping_strips = find_strips_mouse(
-                context, self.frame_start, self.channel_start, self.select_linked)
-            to_select.extend(overlapping_strips)
+                context, self.trim_start, self.channel_start, self.select_linked)
+            to_cut.extend(overlapping_strips)
 
         if self.select_mode == 'cursor' or (not overlapping_strips and
-                                            self.select_mode == 'smart'):
+                                            self.select_mode == 'contextual'):
             for s in context.sequences:
                 if s.lock:
                     continue
-                if s.frame_final_start <= self.frame_start <= s.frame_final_end:
-                    to_select.append(s)
-        return to_select
+                if s.frame_final_start <= self.trim_start <= s.frame_final_end:
+                    to_cut.append(s)
+        return to_cut
 
     def cut_strips_or_gap(self, context, frame_cut):
         if self.cut_gaps and len(context.selected_sequences) == 0:
@@ -225,18 +248,19 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
 
     def find_strips_to_trim(self, context):
         """
-        Finds and Returns two lists of strips to trim and strips to delete
+        Returns two lists of strips to trim and strips to delete
         """
-        to_select, to_delete = [], []
-        # overlapping_strips = []
-        trim_start, trim_end = min(self.frame_start, self.frame_end), max(
-            self.frame_start, self.frame_end)
+        to_trim, to_delete = [], []
 
-        if self.select_mode == 'smart':
-            to_select.extend(self.initially_clicked_strips)
+        trim_start = min(self.trim_start, self.trim_end)
+        trim_end = max(self.trim_start, self.trim_end)
 
-        if self.select_mode == 'cursor' or (not self.initially_clicked_strips and
-                                            self.select_mode == 'smart'):
+        under_mouse = find_strips_mouse(context, self.trim_start, self.channel_start, select_linked=self.select_linked)
+        if self.select_mode == 'contextual':
+            to_trim.extend(under_mouse)
+
+        elif self.select_mode == 'cursor' or \
+           (not self.initially_clicked_strips and self.select_mode == 'contextual'):
             for s in context.sequences:
                 if s.lock:
                     continue
@@ -246,21 +270,33 @@ class POWER_SEQUENCER_OT_mouse_cut(bpy.types.Operator):
                     continue
                 if s.frame_final_start <= trim_start <= s.frame_final_end or \
                    s.frame_final_start <= trim_end <= s.frame_final_end:
-                    to_select.append(s)
-        return to_select, to_delete
+                    to_trim.append(s)
 
+        return to_trim, to_delete
 
-def draw_cut_trim(self, context, start, end, shift_is_pressed):
+def draw(self, context, frame_start=-1, frame_end=-1, mouse_y=-1, target_strips=[], draw_arrows=False):
+    """
+    Draws the line and arrows that represent the trim
+
+    Params:
+    - start and end are Vector(), the start and end of the drawn trim line's vertices in region coordinates
+    """
+    view_to_region = bpy.context.region.view2d.view_to_region
+
+    start = Vector((view_to_region(frame_start, 1)[0], mouse_y))
+    end = Vector((view_to_region(frame_end, 1)[0], mouse_y))
+
     # find channel Y coordinates
     channel_tops = [start.y]
     channel_bottoms = [start.y]
-    for strip in self.target_strips:
-        bottom = context.region.view2d.view_to_region(0, floor(strip.channel))[1]
+
+    for s in target_strips:
+        bottom = view_to_region(0, floor(s.channel))[1]
         if bottom == 12000:
             bottom = 0
         channel_bottoms.append(bottom)
 
-        top = context.region.view2d.view_to_region(0, floor(strip.channel) + 1)[1]
+        top = view_to_region(0, floor(s.channel) + 1)[1]
         if top == 12000:
             top = 0
         channel_tops.append(top)
@@ -271,29 +307,31 @@ def draw_cut_trim(self, context, start, end, shift_is_pressed):
     if start.x > end.x:
         start, end = end, start
 
+    # Drawing
     bgl.glEnable(bgl.GL_BLEND)
+
     bgl.glLineWidth(2)
-
-    # bgl.glPushMatrix()
-
-    # bgl.glColor(1.0, 0.0, 1.0, 1.0)
-
-    # horizontal line
     draw_line(SHADER, start, end)
+    draw_line(SHADER, Vector((start.x, min_bottom)), Vector((start.x, max_top)))
+    draw_line(SHADER, Vector((end.x, min_bottom)), Vector((end.x, max_top)))
 
-    # vertical lines
-    draw_line(SHADER, Vector([start.x, min_bottom]), Vector([start.x, max_top]))
-    draw_line(SHADER, Vector([end.x, min_bottom]), Vector([end.x, max_top]))
-
-    if shift_is_pressed:
+    if draw_arrows:
         first_arrow_center = Vector([start.x + ((end.x - start.x) * 0.25), start.y])
         second_arrow_center = Vector([end.x - ((end.x - start.x) * 0.25), start.y])
         arrow_size = Vector([10, 20])
+
+        bgl.glLineWidth(4)
         draw_arrow_head(SHADER, first_arrow_center, arrow_size)
         draw_arrow_head(SHADER, second_arrow_center, arrow_size, points_right=False)
 
-    # bgl.glPopMatrix()
-
     bgl.glLineWidth(1)
     bgl.glDisable(bgl.GL_BLEND)
-    # bgl.glColor4f(0.0, 0.0, 0.0, 1.0)
+
+
+def get_frame_and_channel(event):
+    """
+    Returns a tuple of (frame, channel)
+    """
+    frame_float, channel_float = bpy.context.region.view2d.region_to_view(
+        x=event.mouse_region_x, y=event.mouse_region_y)
+    return round(frame_float), round(channel_float)

--- a/operators/utils/find_snap_candidate.py
+++ b/operators/utils/find_snap_candidate.py
@@ -1,21 +1,22 @@
 def find_snap_candidate(context, frame=0):
     """
-    Finds and returns the best frame snap candidate around the frame
+    Returns the cut frame closest to the `frame` argument
     """
-    closest_cut_frame = 1000000
+    snap_candidate = 1000000
+
     for s in context.sequences:
         start_to_frame = frame - s.frame_final_start
         end_to_frame = frame - s.frame_final_end
+
         distance_to_start = abs(start_to_frame)
         distance_to_end = abs(end_to_frame)
-        smallest_distance = min(distance_to_start, distance_to_end)
 
-        if smallest_distance == distance_to_start:
-            snap_candidate = frame - start_to_frame
-        else:
-            snap_candidate = frame - end_to_frame
+        candidate = (frame - start_to_frame
+                     if min(distance_to_start, distance_to_end) == distance_to_start
+                     else frame - end_to_frame)
 
-        if abs(frame - snap_candidate) < abs(frame - closest_cut_frame):
-            closest_cut_frame = snap_candidate
-    return closest_cut_frame
+        if abs(frame - candidate) < abs(frame - snap_candidate):
+            snap_candidate = candidate
+
+    return snap_candidate
 


### PR DESCRIPTION
Currently uses T and Shift T to start the operator instead of Ctrl * Click in Power Sequencer 1.2. This is so it doesn't prevent you from using the mouse-based selection tools that are core to Blender 2.80. E.g. Ctrl Click to select all strips left or right of the time cursor.