### PR TITLE
Fixes for some scene related operators

### DIFF
--- a/operators/scene_create_from_selection.py
+++ b/operators/scene_create_from_selection.py
@@ -76,12 +76,12 @@ class POWER_SEQUENCER_OT_scene_create_from_selection(bpy.types.Operator):
         bpy.ops.power_sequencer.preview_to_selection()
 
         # Back to start scene
-        context.screen.scene = bpy.data.scenes[start_scene_name]
+        context.window.scene = bpy.data.scenes[start_scene_name]
 
         bpy.ops.power_sequencer.delete_direct()
         bpy.ops.sequencer.scene_strip_add(
             frame_start=selection_start_frame, channel=selection_start_channel, scene=new_scene_name
         )
         scene_strip = context.selected_sequences[0]
-        scene_strip.use_sequence = True
+        scene_strip.scene_input = 'SEQUENCER'
         return {"FINISHED"}

--- a/operators/scene_open_from_strip.py
+++ b/operators/scene_open_from_strip.py
@@ -49,5 +49,5 @@ class POWER_SEQUENCER_OT_open_scene_strip(bpy.types.Operator):
             return {"FINISHED"}
 
         strip_scene = active_strip.scene
-        context.screen.scene = bpy.data.scenes[strip_scene.name]
+        context.window.scene = bpy.data.scenes[strip_scene.name]
         return {"FINISHED"}


### PR DESCRIPTION
A few scene related operators were still using the old `screen.scene` api instead of the 2.8x analog `window.scene`.

For the "Merge From Scene Strip" operator there were some further logic issues fixed here:
* Add missing context parameter
* Fix exception when there are no markers in the source scene
* Fix misaligned strips after copy
* Fix misaligned markers after copy