### PR TITLE
Fixes Powersequencer Operator: scene_create_from_selection

### DIFF
--- a/operators/scene_create_from_selection.py
+++ b/operators/scene_create_from_selection.py
@@ -53,35 +53,41 @@ class POWER_SEQUENCER_OT_scene_create_from_selection(bpy.types.Operator):
 
     def execute(self, context):
         start_scene_name = context.scene.name
+        
+        if len(context.selected_sequences) != 0:
+            selection = context.selected_sequences[:]
+            selection_start_frame = min(
+                selection, key=attrgetter("frame_final_start")
+            ).frame_final_start
+            selection_start_channel = min(selection, key=attrgetter("channel")).channel
 
-        selection = context.selected_sequences
-        selection_start_frame = min(
-            selection, key=attrgetter("frame_final_start")
-        ).frame_final_start
-        selection_start_channel = min(selection, key=attrgetter("channel")).channel
+            # Create new scene for the scene strip
+            bpy.ops.scene.new(type="FULL_COPY")
+                       
+            context.window.scene.name = context.selected_sequences[0].name
+            print(context.selected_sequences[0].name)
+            new_scene_name = context.window.scene.name
+            
+            
+            ###after full copy also unselected strips are in the sequencer... Delete those strips
+            bpy.ops.sequencer.select_all(action="INVERT")
+            bpy.ops.power_sequencer.delete_direct()
+            frame_offset = selection_start_frame - 1
+            for s in context.sequences:
+                try:
+                    s.frame_start -= frame_offset
+                except Exception:
+                    continue
+            bpy.ops.sequencer.select_all()
+            bpy.ops.power_sequencer.preview_to_selection()
 
-        # Create new scene for the scene strip
-        bpy.ops.scene.new(type="FULL_COPY")
-        new_scene_name = context.scene.name
+            # Back to start scene  
+            bpy.context.window.scene = bpy.data.scenes[start_scene_name]
 
-        bpy.ops.sequencer.select_all(action="INVERT")
-        bpy.ops.power_sequencer.delete_direct()
-        frame_offset = selection_start_frame - 1
-        for s in context.sequences:
-            try:
-                s.frame_start -= frame_offset
-            except Exception:
-                continue
-        bpy.ops.sequencer.select_all()
-        bpy.ops.power_sequencer.preview_to_selection()
-
-        # Back to start scene
-        context.window.scene = bpy.data.scenes[start_scene_name]
-
-        bpy.ops.power_sequencer.delete_direct()
-        bpy.ops.sequencer.scene_strip_add(
-            frame_start=selection_start_frame, channel=selection_start_channel, scene=new_scene_name
-        )
-        scene_strip = context.selected_sequences[0]
-        scene_strip.scene_input = 'SEQUENCER'
+            bpy.ops.power_sequencer.delete_direct()
+            bpy.ops.sequencer.scene_strip_add(
+                frame_start=selection_start_frame, channel=selection_start_channel, scene=new_scene_name
+            )
+            scene_strip = context.selected_sequences[0]
+           # scene_strip.use_sequence = True
         return {"FINISHED"}


### PR DESCRIPTION
-removed error when no strip is selected 
- fixed problems in scene changes code (update to 2.8x) 
-new scene will be renamed automatically after the active strip 

...hope that it helps

**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [ x ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
-removed error when no strip is selected 
- fixed problems in scene changes code (update to 2.8x) 
-new scene will be renamed automatically after the active strip 




**Does this PR introduce a breaking change?**
I quess, renaming the scene after the active strip is not breaking change, but however a question of taste. I think it gives a better overview when working with this awesome operator


## New feature or change ##


**What is the current behavior?** 
scene from strip operator creates error when nothing is selected
scene from strip operator creates error on runtime because code for changing the scene was wrong

**What is the new behavior?**

both error fixes 1. by checking that a strip is at least selected. 2. change the code during scene chage 

**Other information**
There is still no UI entry for the operator, now that its working again, maybe that's a next step

love helping, when this is helpful