### PR TITLE
Update functions.py

### DIFF
--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -291,6 +291,8 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
             bpy.ops.sequencer.split(frame=trim_start, type="SOFT", side="RIGHT")
             bpy.ops.sequencer.split(frame=trim_end, type="SOFT", side="LEFT")
             to_delete.append(context.selected_sequences[0])
+            if s in rescue_selected:
+                rescue_selected.append(context.sequences[0])
             continue
 
         # Resize strips that overlap the trim range

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -281,6 +281,9 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
     rescue_selected = context.selected_sequences
 
     for s in to_trim:
+        # List with strips that are in the target channel. Used for the reselection
+        strips_in_target_channel = []
+        
         # Cut strip longer than the trim range in three
         is_strip_longer_than_trim_range = (
             s.frame_final_start < trim_start and s.frame_final_end > trim_end
@@ -291,8 +294,13 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
             bpy.ops.sequencer.split(frame=trim_start, type="SOFT", side="RIGHT")
             bpy.ops.sequencer.split(frame=trim_end, type="SOFT", side="LEFT")
             to_delete.append(context.selected_sequences[0])
+            
+            for c in context.sequences:
+                if c.channel == s.channel:
+                    strips_in_target_channel.append(c)
+            
             if s in rescue_selected:
-                rescue_selected.append(context.sequences[0])
+                rescue_selected.append(strips_in_target_channel[0])
             continue
 
         # Resize strips that overlap the trim range

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -278,6 +278,7 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
     trim_end = max(frame_start, frame_end)
 
     to_trim = [s for s in to_trim if s.type in SequenceTypes.CUTABLE]
+    rescue_selected = context.selected_sequences
 
     for s in to_trim:
         # Cut strip longer than the trim range in three
@@ -299,6 +300,8 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
             s.frame_final_end = trim_start
 
     delete_strips(to_delete)
+    for s in rescue_selected:
+        s.select = True
     return {"FINISHED"}
 
 


### PR DESCRIPTION
It's not exactly a bug, but when trimming a a strip bigger than the one moved, all of the strips are deselected. What I do here is to reselect by saving the tuple, and the pass a for loop at the end.
The result is a much smoother modification of the strips, as you don't need to reselect the moved strip.
I thought it would be better do it here, as it's here where it's being deselected, not in the channel_offset.py (I found out this issue while working in this file).