### PR TITLE
Refactor channel_offset.py

### DIFF
--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -23,7 +23,7 @@ from .utils.functions import (
     trim_strips,
     find_strips_in_range,
     move_selection,
-    pixel_frame_ratio,
+    calculate_pixel_frame_ratio,
 )
 
 
@@ -110,7 +110,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         if not selection:
             return {"FINISHED"}
         
-        range_block = round(47 * pixel_frame_ratio(context, "x"))
+        range_block = round(47 * calculate_pixel_frame_ratio(context, "x"))
         '''
         If keep_selection_offset, sets all the strips by blocks. The blocks consists of strips
         close enough between each other. The minimum distance is range_block, which uses the real
@@ -118,7 +118,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         in the same block the larger the view is, and viceversa.
         Parts:
             - Arbitrary number which is convinient for the functionality. Bigger means more apart.
-            - pixel_frame_ratio("x") gives the current relation frame/pixel on screen of the sequencer panel in
+            - calculate_pixel_frame_ratio("x") gives the current relation frame/pixel on screen of the sequencer panel in
             the given axis.
         '''
 

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -18,13 +18,6 @@ import bpy
 from operator import attrgetter
 
 from .utils.doc import doc_name, doc_idname, doc_brief, doc_description
-from .utils.functions import (
-    slice_selection,
-    get_frame_range,
-    get_channel_range,
-    trim_strips,
-    find_strips_in_range,
-)
 
 
 class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
@@ -39,7 +32,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         "shortcuts": [
             (
                 {"type": "UP_ARROW", "value": "PRESS", "alt": True},
-                {"direction": "up"},
+                {"direction": "up", "trim_target_channel": False},
                 "Move to Open Channel Above",
             ),
             (
@@ -49,7 +42,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
             ),
             (
                 {"type": "DOWN_ARROW", "value": "PRESS", "alt": True},
-                {"direction": "down"},
+                {"direction": "down", "trim_target_channel": False},
                 "Move to Open Channel Below",
             ),
             (
@@ -85,29 +78,119 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         return context.selected_sequences
 
     def execute(self, context):
-        selection = [s for s in context.selected_sequences if not s.lock]
+        
+        max_channel = 32
+        min_channel = 1
+
+        selection = [s for s in context.selected_sequences if (
+            not s.lock and not (self.direction == "down" and s.channel == min_channel)
+            and not (self.direction == "up" and s.channel == max_channel)
+        )]
         if not selection:
             return {"FINISHED"}
+        
+        # Sorts the "selection" list depending of the key press.
+        # If the key press is down, the order of moving will begin from the bottom channel,
+        # otherwise from the top.
+        if self.direction == "down":
+            selection = sorted(selection, key=attrgetter("channel", "frame_final_start"))
+        else:
+            selection = reversed(sorted(selection, key=attrgetter("channel", "frame_final_start")))
 
-        selection_blocks = slice_selection(context, selection)
-        for block in selection_blocks:
-            sequences = sorted(block, key=attrgetter("channel", "frame_final_start"))
-            frame_start, frame_end = get_frame_range(sequences)
-            channel_start, channel_end = get_channel_range(sequences)
+        # Saves all selected strips to reselect them after the operation.
+        rescue_selected = context.selected_sequences
+
+        for moving_strip in selection:
 
             if self.trim_target_channel:
-                to_delete, to_trim = find_strips_in_range(frame_start, frame_end, context.sequences)
-                channel_trim = (
-                    channel_end + 1 if self.direction == "up" else max(1, channel_start - 1)
+
+                to_delete = []
+                strips_in_target_channel = []
+                target_channel = (
+                    min(max_channel, moving_strip.channel + 1) if self.direction == "up" 
+                    else max(min_channel, moving_strip.channel - 1)
                 )
-                to_trim = [s for s in to_trim if s.channel == channel_trim]
-                to_delete = [s for s in to_delete if s.channel == channel_trim]
-                trim_strips(context, frame_start, frame_end, to_trim, to_delete)
+
+                # s is any strip able to move.
+                for target_strip in context.sequences:
+
+                    # Makes it easier to read.
+                    moving_start = moving_strip.frame_final_start
+                    moving_end = moving_strip.frame_final_end
+                    target_start = target_strip.frame_final_start
+                    target_end = target_strip.frame_final_end
+                    
+                    # Checks if the moving strip could interact with the target strip.
+                    if (
+                        (target_strip.channel == target_channel)
+                        and not (target_end < moving_start or target_start > moving_end)
+                    ):
+                        bpy.ops.sequencer.select_all(action="DESELECT")
+
+                        ###########################################################################
+                        # Delete:
+                        
+                        # Makes a list with all strips that will be deleted if they are completely
+                        # inside the range of the moving strip.
+                        if (
+                            moving_start <= target_start <= moving_end
+                            and moving_start <= target_end <= moving_end
+                        ):
+                            to_delete.append(target_strip)
+                            continue
+
+                        ###########################################################################
+                        # Trim: 
+
+                        # If the target strip's start/end are inside moving strip's range: divide
+                        # in 3, delete the middle and select the last if the target was selected.
+                        if (
+                            target_start < moving_start and target_end > moving_end
+                        ):
+                            target_strip.select = True
+                            bpy.ops.sequencer.split(frame=moving_start, type="SOFT", side="RIGHT")
+                            bpy.ops.sequencer.split(frame=moving_end, type="SOFT", side="LEFT")
+                            to_delete.append(context.selected_sequences[0])
+
+                            # Sets all strips in the target channel in a tuple.
+                            # It's to correctly reselect the remaining bits of the trimmed strip.
+                            for s in context.sequences:
+                                if s.channel == target_channel:
+                                    strips_in_target_channel.append(s)
+
+                            # Appends the last trimmed strip to the rescue list
+                            if target_strip in rescue_selected:
+                                rescue_selected.append(strips_in_target_channel[0])
+                            continue
+
+                        # If the target strip's end is outside moving strip's range, trim target
+                        # strip's start.
+                        elif (
+                            target_start < moving_end and target_end > moving_end
+                        ):
+                            target_strip.frame_final_start = moving_strip.frame_final_end
+
+                        # If the target strip's start is outside moving strip's range, trim target
+                        # strip's end.
+                        elif (
+                            target_end > moving_start and target_start < moving_start
+                        ):
+                            target_strip.frame_final_end = moving_strip.frame_final_start
+
+                        ###########################################################################
+
+                # Deletes all strips in "to_delete" by selecting them.
+                bpy.ops.sequencer.select_all(action="DESELECT")
+                for s in to_delete:
+                    s.select = True
+                bpy.ops.sequencer.delete()
+                
+                # Reselects all the initial strips.
+                for s in rescue_selected:
+                    s.select = True
 
             if self.direction == "up":
-                for s in reversed(sequences):
-                    s.channel += 1
+                moving_strip.channel = min(max_channel, moving_strip.channel + 1)
             elif self.direction == "down":
-                for s in sequences:
-                    s.channel = max(1, s.channel - 1)
+                moving_strip.channel = max(min_channel, moving_strip.channel - 1)
         return {"FINISHED"}

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -112,9 +112,10 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         
         range_block = round(47 * zoom(context, "x"))
         '''
-        This way the strips will be considered as one block depending on how far apart are the
-        strips between each other in frames/pixels instead of frames. It feels more natural to the
-        user.q
+        If keep_selection_offset, sets all the strips by blocks. The blocks consists of strips
+        close enough between each other. The minimum distance is range_block, which uses the real
+        distance from the screen (pixel/frame) and not just frames. That means more strips will
+        in the same block the larger the view is, and viceversa.
         Parts:
             - Arbitrary number which is convinient for the functionality. Bigger means more apart.
             - zoom("x") gives the current relation frame/pixel on screen of the sequencer panel in
@@ -139,10 +140,10 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
 
                         channel_trim = movement_to_limit(limit_channel, s.channel + movement)
                         all_strips = [c for c in context.sequences if c.channel == channel_trim]
-                        to_delete, to_trim = find_strips_in_range(s.frame_final_start, s.frame_final_end, all_strips)
-                        trim_strips(context, s.frame_final_start, s.frame_final_end, to_trim, to_delete)
+                        if all_strips:
+                            to_delete, to_trim = find_strips_in_range(s.frame_final_start, s.frame_final_end, all_strips)
+                            trim_strips(context, s.frame_final_start, s.frame_final_end, to_trim, to_delete)
                         s.channel = movement_to_limit(limit_channel, s.channel + movement)
-
                         to_remove.append(s)
                     for s in to_remove:
                         sequences.remove(s)

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -23,7 +23,7 @@ from .utils.functions import (
     trim_strips,
     find_strips_in_range,
     move_selection,
-    zoom,
+    pixel_frame_ratio,
 )
 
 
@@ -110,7 +110,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         if not selection:
             return {"FINISHED"}
         
-        range_block = round(47 * zoom(context, "x"))
+        range_block = round(47 * pixel_frame_ratio(context, "x"))
         '''
         If keep_selection_offset, sets all the strips by blocks. The blocks consists of strips
         close enough between each other. The minimum distance is range_block, which uses the real
@@ -118,7 +118,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         in the same block the larger the view is, and viceversa.
         Parts:
             - Arbitrary number which is convinient for the functionality. Bigger means more apart.
-            - zoom("x") gives the current relation frame/pixel on screen of the sequencer panel in
+            - pixel_frame_ratio("x") gives the current relation frame/pixel on screen of the sequencer panel in
             the given axis.
         '''
 

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -23,7 +23,7 @@ from .utils.functions import (
     trim_strips,
     find_strips_in_range,
     move_selection,
-    calculate_pixel_frame_ratio,
+    calculate_frame_pixel_ratio,
 )
 
 
@@ -110,7 +110,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         if not selection:
             return {"FINISHED"}
         
-        range_block = round(47 * calculate_pixel_frame_ratio(context, "x"))
+        range_block = round(47 * calculate_frame_pixel_ratio(context, "x"))
         '''
         If keep_selection_offset, sets all the strips by blocks. The blocks consists of strips
         close enough between each other. The minimum distance is range_block, which uses the real
@@ -118,7 +118,7 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         in the same block the larger the view is, and viceversa.
         Parts:
             - Arbitrary number which is convinient for the functionality. Bigger means more apart.
-            - calculate_pixel_frame_ratio("x") gives the current relation frame/pixel on screen of the sequencer panel in
+            - calculate_frame_pixel_ratio("x") gives the current relation frame/pixel on screen of the sequencer panel in
             the given axis.
         '''
 

--- a/operators/channel_offset.py
+++ b/operators/channel_offset.py
@@ -92,10 +92,9 @@ class POWER_SEQUENCER_OT_channel_offset(bpy.types.Operator):
         # Sorts the "selection" list depending of the key press.
         # If the key press is down, the order of moving will begin from the bottom channel,
         # otherwise from the top.
-        if self.direction == "down":
-            selection = sorted(selection, key=attrgetter("channel", "frame_final_start"))
-        else:
-            selection = reversed(sorted(selection, key=attrgetter("channel", "frame_final_start")))
+        selection = sorted(selection, key=attrgetter("channel", "frame_final_start"))
+        if self.direction == "up":
+            selection = reversed(selection)
 
         # Saves all selected strips to reselect them after the operation.
         rescue_selected = context.selected_sequences

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -419,33 +419,6 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
     return strips_inside_range, strips_overlapping_range
 
 
-def calculate_frame_pixel_ratio(context, axis):
-    """
-    Returns frame/pixel relation in the current view.
-    There's an internal bug which the bpy.context.region.x is wrongly assigned when the toolbar is toggled.
-    """
-    context.space_data.show_region_toolbar = False
-
-    region_width = context.region.width
-    region_height = context.region.height
-
-    # Coordinates from bottom_left corner
-    region_xs = context.region.x
-    region_ys = context.region.y
-    region_xe = region_width + region_xs
-    region_ye = region_height + region_ys
-
-    context.space_data.show_region_toolbar = True
-
-    xs, ys = context.region.view2d.region_to_view(region_xs, region_ys)
-    xe, ye = context.region.view2d.region_to_view(region_xe, region_ye)
-            
-    if axis == "x":
-        return (xe-xs)/region_width
-    else:
-        return (ye-ys)/region_height
-
-
 def move_selection(context, sequences, x, y):
     """
     Moves the "sequences" list as says the vector (x,y) and preserves the current selected sequences.

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -419,7 +419,7 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
     return strips_inside_range, strips_overlapping_range
 
 
-def pixel_frame_ratio(context, axis):
+def calculate_frame_pixel_ratio(context, axis):
     """
     Returns frame/pixel relation in the current view.
     There's an internal bug which the bpy.context.region.x is wrongly assigned when the toolbar is toggled.

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -21,6 +21,9 @@ import bpy
 
 from .global_settings import SequenceTypes
 
+max_channel = 32
+min_channel = 1
+
 
 def calculate_distance(x1, y1, x2, y2):
     return sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
@@ -34,10 +37,8 @@ def find_linked(context, sequences, selected_sequences):
     """
     Takes a list of sequences and returns a list of all the sequences
     and effects that are linked in time
-
     Args:
-    - sequences: a list of sequences
-
+        - sequences: a list of sequences
     Returns a list of all the linked sequences, but not the sequences passed to the function
     """
     start, end = get_frame_range(sequences, selected_sequences)
@@ -99,7 +100,7 @@ def find_sequences_after(context, sequence):
     """
     Finds the strips following the sequences passed to the function
     Args:
-    - Sequences, the sequences to check
+        - Sequences, the sequences to check
     Returns all the strips after the sequence in the current context
     """
     return [s for s in context.sequences if s.frame_final_start > sequence.frame_final_start]
@@ -133,12 +134,10 @@ def find_snap_candidate(context, frame=0):
 def find_strips_mouse(context, frame, channel, select_linked=False):
     """
     Finds a list of sequences to select based on the frame and channel the mouse cursor is at
-
     Args:
-    - frame: the frame the mouse or cursor is on
-    - channel: the channel the mouse is hovering
-    - select_linked: find and append the sequences linked in time if True
-
+        - frame: the frame the mouse or cursor is on
+        - channel: the channel the mouse is hovering
+        - select_linked: find and append the sequences linked in time if True
     Returns the sequence(s) under the mouse cursor as a list
     Returns an empty list if nothing found
     """
@@ -201,10 +200,9 @@ def get_mouse_frame_and_channel(context, event):
 def is_in_range(context, sequence, start, end):
     """
     Checks if a single sequence's start or end is in the range
-
     Args:
-    - sequence: the sequence to check for
-    - start, end: the start and end frames
+        - sequence: the sequence to check for
+        - start, end: the start and end frames
     Returns True if the sequence is within the range, False otherwise
     """
     s_start = sequence.frame_final_start
@@ -238,34 +236,18 @@ def slice_selection(context, sequences):
     if not sequences:
         return []
 
-    break_ids = [0]
-    sorted_sequences = sorted(sequences, key=attrgetter("frame_final_start"))
-    last_sequence = sorted_sequences[0]
-    last_biggest_frame_end = last_sequence.frame_final_end
-    index = 0
-    for s in sorted_sequences:
-        if s.frame_final_start > last_biggest_frame_end + 1:
-            break_ids.append(index)
-        last_biggest_frame_end = max(last_biggest_frame_end, s.frame_final_end)
-        last_sequence = s
-        index += 1
-
-    # Create lists
-    break_ids.append(len(sorted_sequences))
-    cuts_count = len(break_ids) - 1
+    # Indicates the index number of the lists from the "broken_selection" list
+    index = -1
     broken_selection = []
-    index = 0
-    while index < cuts_count:
-        temp_list = []
-        index_range = range(break_ids[index], break_ids[index + 1] - 1)
-        if len(index_range) == 0:
-            temp_list.append(sorted_sequences[break_ids[index]])
-        else:
-            for counter in range(break_ids[index], break_ids[index + 1]):
-                temp_list.append(sorted_sequences[counter])
-        if temp_list:
-            broken_selection.append(temp_list)
-        index += 1
+    sorted_sequences = sorted(sequences, key=attrgetter("frame_final_start"))
+
+    for s in sorted_sequences:
+        if not broken_selection or (broken_selection[index][-1].frame_final_end + 1 + range_block < s.frame_final_start):
+            broken_selection.append([s])
+            index += 1
+            continue
+        broken_selection[index].append(s)
+
     return broken_selection
 
 
@@ -278,8 +260,10 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
     trim_end = max(frame_start, frame_end)
 
     to_trim = [s for s in to_trim if s.type in SequenceTypes.CUTABLE]
+    initial_selection = context.selected_sequences
 
     for s in to_trim:
+        strips_in_target_channel = []
         # Cut strip longer than the trim range in three
         is_strip_longer_than_trim_range = (
             s.frame_final_start < trim_start and s.frame_final_end > trim_end
@@ -290,6 +274,13 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
             bpy.ops.sequencer.split(frame=trim_start, type="SOFT", side="RIGHT")
             bpy.ops.sequencer.split(frame=trim_end, type="SOFT", side="LEFT")
             to_delete.append(context.selected_sequences[0])
+            
+            for c in context.sequences:
+                if c.channel == s.channel:
+                    strips_in_target_channel.append(c)
+            
+            if s in initial_selection:
+                initial_selection.append(strips_in_target_channel[0])
             continue
 
         # Resize strips that overlap the trim range
@@ -299,6 +290,8 @@ def trim_strips(context, frame_start, frame_end, to_trim, to_delete=[]):
             s.frame_final_end = trim_start
 
     delete_strips(to_delete)
+    for s in initial_selection:
+        s.select = True
     return {"FINISHED"}
 
 
@@ -378,15 +371,7 @@ def ripple_move(context, sequences, duration_frames, delete=False):
     else:
         to_ripple = set(to_ripple + sequences)
 
-    # Use the built-in seq_slide operator to move strips, for best performances
-    initial_selection = context.selected_sequences
-    bpy.ops.sequencer.select_all(action="DESELECT")
-    for s in to_ripple:
-        s.select = True
-    bpy.ops.transform.seq_slide(value=(duration_frames, 0))
-    bpy.ops.sequencer.select_all(action="DESELECT")
-    for s in initial_selection:
-        s.select = True
+    move_selection(context, to_ripple, duration_frames, 0)
 
 
 def apply_time_offset(context, sequences=[], offset=0):
@@ -394,14 +379,7 @@ def apply_time_offset(context, sequences=[], offset=0):
     user's selection. Use this function to ensure maximum performances and avoid having to figure
     out the logic to move strips in the right order.
     """
-    selection = context.selected_sequences
-    bpy.ops.sequencer.select_all(action="DESELECT")
-    for s in sequences:
-        s.select = True
-    bpy.ops.transform.seq_slide(value=(offset, 0))
-    bpy.ops.sequencer.select_all(action="DESELECT")
-    for s in selection:
-        s.select = True
+    move_selection(context, to_ripple, duration_frames, 0)
 
 
 def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=True):
@@ -409,18 +387,18 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
     Returns a tuple of two lists: (strips_inside_range, strips_overlapping_range)
     strips_inside_range are strips entirely contained in the frame range.
     strips_overlapping_range are strips that only overlap the frame range.
-
     Args:
-    - frame_start, the start of the frame range
-    - frame_end, the end of the frame range
-    - sequences (optional): only work with these sequences.
-    If it doesn't receive any, the function works with all the sequences in the current context
-    - find_overlapping (optional): find and return a list of strips that overlap the
+        - frame_start, the start of the frame range
+        - frame_end, the end of the frame range
+        - sequences (optional): only work with these sequences.
+        If it doesn't receive any, the function works with all the sequences in the current context
+        - find_overlapping (optional): find and return a list of strips that overlap the
         frame range
-
     """
     strips_inside_range = []
     strips_overlapping_range = []
+    if not sequences:
+        sequences = bpy.context.sequences
     for s in sequences:
         if (
             frame_start <= s.frame_final_start <= frame_end
@@ -429,8 +407,8 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
             strips_inside_range.append(s)
         elif find_overlapping:
             if (
-                frame_start <= s.frame_final_end <= frame_end
-                or frame_start <= s.frame_final_start <= frame_end
+                frame_start < s.frame_final_end <= frame_end
+                or frame_start <= s.frame_final_start < frame_end
             ):
                 strips_overlapping_range.append(s)
 
@@ -438,3 +416,46 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
             if s.frame_final_start < frame_start and s.frame_final_end > frame_end:
                 strips_overlapping_range.append(s)
     return strips_inside_range, strips_overlapping_range
+
+
+def zoom(context, axis):
+    """
+    Returns frame/pixel relation in the current view.
+    There's an internal bug which the bpy.context.region.x is wrongly assigned when the toolbar is toggled.
+    """
+    context.space_data.show_region_toolbar = False
+
+    region_width = context.region.width
+    region_height = context.region.height
+
+    # Coordinates from bottom_left corner
+    region_xs = context.region.x
+    region_ys = context.region.y
+    region_xe = region_width + region_xs
+    region_ye = region_height + region_ys
+
+    context.space_data.show_region_toolbar = True
+
+    xs, ys = context.region.view2d.region_to_view(region_xs, region_ys)
+    xe, ye = context.region.view2d.region_to_view(region_xe, region_ye)
+            
+    if axis == "x":
+        return (xe-xs)/region_width
+    else:
+        return (ye-ys)/region_height
+
+
+def move_selection(context, sequences, x, y):
+    """
+    Moves the "sequences" list as says the vector (x,y) and preserves the current selected sequences.
+    """
+    if not sequences:
+        return
+    initial_selection = context.selected_sequences
+    bpy.ops.sequencer.select_all(action="DESELECT")
+    for s in sequences:
+        s.select = True
+    bpy.ops.transform.seq_slide(value=(x, y))
+    bpy.ops.sequencer.select_all(action="DESELECT")
+    for s in initial_selection:
+        s.select = True

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -236,14 +236,17 @@ def slice_selection(context, sequences, range_block=0):
 
     # Indicates the index number of the lists from the "broken_selection" list
     index = -1
+    block_end = 0
     broken_selection = []
     sorted_sequences = sorted(sequences, key=attrgetter("frame_final_start"))
 
     for s in sorted_sequences:
-        if not broken_selection or (broken_selection[index][-1].frame_final_end + 1 + range_block < s.frame_final_start):
+        if not broken_selection or (block_end + 1 + range_block < s.frame_final_start):
             broken_selection.append([s])
+            block_end = s.frame_final_end
             index += 1
             continue
+        block_end = max(block_end, s.frame_final_end)
         broken_selection[index].append(s)
 
     return broken_selection

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -223,16 +223,14 @@ def set_preview_range(context, start, end):
     scene.frame_preview_end = end
 
 
-def slice_selection(context, sequences):
+def slice_selection(context, sequences, range_block=0):
     """
     Takes a list of sequences and breaks it down
     into multiple lists of connected sequences
-
     Returns a list of lists of sequences,
     each list corresponding to a block of sequences
     that are connected in time and sorted by frame_final_start
     """
-    # Find when 2 sequences are not connected in time
     if not sequences:
         return []
 

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -380,7 +380,7 @@ def apply_time_offset(context, sequences=[], offset=0):
     user's selection. Use this function to ensure maximum performances and avoid having to figure
     out the logic to move strips in the right order.
     """
-    move_selection(context, to_ripple, duration_frames, 0)
+    move_selection(context, sequences, offset, 0)
 
 
 def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=True):

--- a/operators/utils/functions.py
+++ b/operators/utils/functions.py
@@ -416,7 +416,7 @@ def find_strips_in_range(frame_start, frame_end, sequences, find_overlapping=Tru
     return strips_inside_range, strips_overlapping_range
 
 
-def zoom(context, axis):
+def pixel_frame_ratio(context, axis):
     """
     Returns frame/pixel relation in the current view.
     There's an internal bug which the bpy.context.region.x is wrongly assigned when the toolbar is toggled.


### PR DESCRIPTION
This solves a bug of wrongly trimming and deleting when doing it with 2 or more strips selected.

To trigger it, create 3 strips in 3 channels like:
3: ░░░▓▓▓▓▓▓▓▓▓▓░░
2: ░░░░░▓▓░░░░░░░░
1: ██████████░░░░░
Select the 2 from above and trim them down (ctrl + alt + down_arrow). The result is not the espected:
3: ░░░░░░░░░░░░░░░
2: ░░░▓▓▓▓▓▓▓▓▓▓░░
1: ███░░▓▓░░░░░░░░
Spected result:
3: ░░░░░░░░░░░░░░░
2: ░░░▓▓▓▓▓▓▓▓▓▓░░
1: █████▓▓███░░░░░

To solve the issue, I had to refactor the code and make the changes strip by strip, instead of block by block.
This allows to operate each strip individually and to set personalized range of trimming for each bit.
Since it now operates with changing ranges, I had to import all the operations from external files.
I know it's not "the blender way", but I was afraid to break compatibility.

I have also applied all changes from the pull requests done by me yesterday (crash when trimming down in channel 1,
upper limit, and disable the trimming when using alt + up/down_arrow).
Of course I also added the fixes for the function.py pull, since I had to import all functionalities.