### PR TITLE
Fix for AttributeError: 'Context' object has no attribute 'active_node'

### DIFF
--- a/operators/make_hold_frame.py
+++ b/operators/make_hold_frame.py
@@ -37,7 +37,7 @@ class POWER_SEQUENCER_OT_make_hold_frame(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.scene.sequence_editor.active_strip.type in SequenceTypes.VIDEO
+        return context.scene.sequence_editor.active_strip.type in SequenceTypes.VIDEO if context.scene.sequence_editor.active_strip is not None else None
 
     def invoke(self, context, event):
         window_manager = context.window_manager

--- a/operators/speed_remove_effect.py
+++ b/operators/speed_remove_effect.py
@@ -28,7 +28,7 @@ class POWER_SEQUENCER_OT_speed_remove_effect(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.scene.sequence_editor.active_strip.type == "META"
+        return context.scene.sequence_editor.active_strip.type == "META" if context.scene.sequence_editor.active_strip is not None else None
 
     def execute(self, context):
         active = context.scene.sequence_editor.active_strip


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix for AttributeError: 'Context' object has no attribute 'active_node' error in make_hold_frame and speed_remove_effect when attempting to access attributes on the context object, it returns None type in some contexts.


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
When I activate discombobulator on just a regular, stock cube object and execute it (I don't think this is specific to that operator, it's just where I noticed it and what I use to reproduce it), Power Sequencer give me this error in the logs:

```
Python: Traceback (most recent call last):
  File "{BLENDER_PATH}\blender-4.0.2-windows-x64\4.0\scripts\addons\power_sequencer\operators\speed_remove_effect.py", line 133, in poll
    if context.active_node is not None :
AttributeError: 'Context' object has no attribute 'active_node'. Did you mean: 'active_bone'?
```

**What is the new behavior?**
No error occurs in logs while unrelated operator execution takes place.